### PR TITLE
Define input monad class for parser

### DIFF
--- a/flesh.cabal
+++ b/flesh.cabal
@@ -18,6 +18,7 @@ library
   exposed-modules:     Flesh.Language.Alias,
                        Flesh.Language.Alias.Core,
                        Flesh.Language.Parser.Alias,
+                       Flesh.Language.Parser.Char,
                        Flesh.Language.Parser.Error,
                        Flesh.Language.Parser.HereDoc,
                        Flesh.Language.Parser.Input,

--- a/flesh.cabal
+++ b/flesh.cabal
@@ -23,8 +23,9 @@ library
                        Flesh.Language.Parser.HereDoc,
                        Flesh.Language.Parser.Input,
                        Flesh.Language.Parser.Warning,
+                       Flesh.Language.Syntax,
                        Flesh.Source.Position
-  build-depends:       base >= 4.7 && < 5,
+  build-depends:       base >= 4.9 && < 5,
                        mtl >= 2.2.1 && < 2.3,
                        transformers >= 0.4 && < 0.6
   ghc-options:         -Wall

--- a/src/Flesh/Language/Parser/Char.hs
+++ b/src/Flesh/Language/Parser/Char.hs
@@ -33,7 +33,7 @@ import Flesh.Source.Position
 -- | Parses a single character that satisfies the given predicate.
 --
 -- Returns 'UnknownReason' on dissatisfaction.
-satisfy :: (MonadPosition n m, MonadAttempt m)
+satisfy :: (MonadInput m, MonadAttempt m)
         => (Char -> Bool) -> m (Positioned Char)
 satisfy pred_ = do
   e <- popChar
@@ -45,24 +45,24 @@ satisfy pred_ = do
 -- | Parses the given single character.
 --
 -- Returns 'UnknownReason' on failure.
-char :: (MonadPosition n m, MonadAttempt m) => Char -> m (Positioned Char)
+char :: (MonadInput m, MonadAttempt m) => Char -> m (Positioned Char)
 char c = satisfy (c ==)
 
 -- | Parses any single character.
 --
 -- Returns 'UnknownReason' if there is no next character.
-anyChar :: (MonadPosition n m, MonadAttempt m) => m (Positioned Char)
+anyChar :: (MonadInput m, MonadAttempt m) => m (Positioned Char)
 anyChar = satisfy (const True)
 
 -- | Parses a sequence of characters.
 --
 -- Returns 'UnknownReason' on failure.
-string :: (MonadPosition n m, MonadAttempt m) => String -> m [Positioned Char]
+string :: (MonadInput m, MonadAttempt m) => String -> m [Positioned Char]
 string [] = return []
 string (c:cs) = (:) <$> char c <*> string cs
 
 -- | Parses the /end-of-file/.
-eof :: (MonadPosition n m, MonadAttempt m) => m Position
+eof :: (MonadInput m, MonadAttempt m) => m Position
 eof = do
   e <- peekChar
   case e of

--- a/src/Flesh/Language/Parser/Char.hs
+++ b/src/Flesh/Language/Parser/Char.hs
@@ -1,0 +1,72 @@
+{-
+Copyright (C) 2017 WATANABE Yuki <magicant@wonderwand.net>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-}
+
+{-# LANGUAGE Safe #-}
+
+{-|
+Copyright   : (C) 2017 WATANABE Yuki
+License     : GPL-2
+Portability : portable
+
+This module defines character parsers.
+-}
+module Flesh.Language.Parser.Char where
+
+import Flesh.Language.Parser.Error
+import Flesh.Language.Parser.Input
+import Flesh.Source.Position
+
+-- | Parses a single character that satisfies the given predicate.
+--
+-- Returns 'UnknownReason' on dissatisfaction.
+satisfy :: (MonadPosition n m, MonadAttempt m)
+        => (Char -> Bool) -> m (Positioned Char)
+satisfy pred_ = do
+  e <- popChar
+  case e of
+    Left pos -> failure' pos
+    Right pc@(pos, c) | pred_ c   -> return pc
+                      | otherwise -> failure' pos
+
+-- | Parses the given single character.
+--
+-- Returns 'UnknownReason' on failure.
+char :: (MonadPosition n m, MonadAttempt m) => Char -> m (Positioned Char)
+char c = satisfy (c ==)
+
+-- | Parses any single character.
+--
+-- Returns 'UnknownReason' if there is no next character.
+anyChar :: (MonadPosition n m, MonadAttempt m) => m (Positioned Char)
+anyChar = satisfy (const True)
+
+-- | Parses a sequence of characters.
+--
+-- Returns 'UnknownReason' on failure.
+string :: (MonadPosition n m, MonadAttempt m) => String -> m [Positioned Char]
+string [] = return []
+string (c:cs) = (:) <$> char c <*> string cs
+
+-- | Parses the /end-of-file/.
+eof :: (MonadPosition n m, MonadAttempt m) => m Position
+eof = do
+  e <- peekChar
+  case e of
+    Left pos -> return pos
+    Right (pos, _) -> failure' pos
+
+-- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -35,7 +35,7 @@ module Flesh.Language.Parser.Error (
   -- * The AttemptT monad transformer
   AttemptT(..), attempt, runAttemptT, mapAttemptT,
   -- * Class of attempt monads
-  MonadAttempt(..), failure, recover) where
+  MonadAttempt(..), failure, failure', recover) where
 
 import Control.Applicative
 import Control.Monad.Except
@@ -184,6 +184,10 @@ instance (Monoid w, MonadAttempt m) => MonadAttempt (WS.WriterT w m) where
 -- | Returns a failed attempt with the given (hard) error.
 failure :: MonadError (Severity, Error) m => Error -> m a
 failure e = throwError (Hard, e)
+
+-- | Failure of unknown reason.
+failure' :: MonadError (Severity, Error) m => P.Position -> m a
+failure' p = failure (Error {reason = UnknownReason, position = p})
 
 -- | Recovers from an error. This is a simple wrapper around 'catchError' that
 -- ignores the error's 'Severity'.

--- a/src/Flesh/Language/Parser/Input.hs
+++ b/src/Flesh/Language/Parser/Input.hs
@@ -15,21 +15,25 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -}
 
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE Safe #-}
 
 {-|
 Copyright   : (C) 2017 WATANABE Yuki
 License     : GPL-2
-Portability : portable
+Portability : non-portable (GHC language extensions)
 
 This module defines types and functions for reading input for the syntax
 parser.
 -}
 module Flesh.Language.Parser.Input (
   InputT(..), prepend,
-  PositionT) where
+  PositionT, MonadPosition(..)) where
 
 import Flesh.Source.Position
+import Control.Monad.Reader
 import Control.Monad.State.Strict
 
 -- | Monad for reading input.
@@ -43,10 +47,46 @@ newtype InputT m = InputT (m (Either Position (Positioned Char, InputT m)))
 
 -- | @prepend cs m@ returns an input monad that first yields the elements of
 -- @cs@ and then @m@.
-prepend :: [Positioned Char] -> InputT m -> InputT m
-prepend = undefined -- FIXME
+prepend :: Monad m => [Positioned Char] -> InputT m -> InputT m
+prepend [] m = m
+prepend (c:cs) m = InputT (return (Right (c, prepend cs m)))
 
 -- | Monad transformer that manages input position as a state.
-type PositionT n = StateT (InputT n)
+type PositionT m = StateT (InputT m)
+
+-- | Extension of 'MonadState' that allows character input operations.
+class MonadState (InputT n) m => MonadPosition n m where
+  -- | Returns the character at the current position without advancing the
+  -- position.
+  peekChar :: m (Either Position (Positioned Char))
+  -- | Reads one character at the current position and advancing the position
+  -- to the next character.
+  popChar :: m (Either Position (Positioned Char))
+  -- | Returns the result of the given parser without advancing the input
+  -- position.
+  followedBy :: m a -> m a
+
+instance Monad m => MonadPosition m (StateT (InputT m) m) where
+  peekChar = do
+    InputT i <- get
+    lift (fmap (fmap fst) i)
+  popChar = do
+    InputT i1 <- get
+    e <- lift i1
+    case e of
+      Left p -> return (Left p)
+      Right (c, i2) -> do
+        put i2
+        return (Right c)
+  followedBy m = do
+    i <- get
+    a <- m
+    put i
+    return a
+
+instance MonadPosition n m => MonadPosition n (ReaderT r m) where
+  peekChar = lift peekChar
+  popChar = lift popChar
+  followedBy = mapReaderT followedBy
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Parser/Input.hs
+++ b/src/Flesh/Language/Parser/Input.hs
@@ -15,7 +15,6 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -}
 
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE Safe #-}
@@ -29,64 +28,48 @@ This module defines types and functions for reading input for the syntax
 parser.
 -}
 module Flesh.Language.Parser.Input (
-  InputT(..), prepend,
-  PositionT, MonadPosition(..)) where
+  MonadInput(..), currentPosition) where
 
 import Flesh.Source.Position
-import Control.Monad.Reader
-import Control.Monad.State.Strict
 
--- | Monad for reading input.
+-- | Monad for character input operations.
 --
--- The monad should simply return a single position (denoting the end of
--- input) or a pair of a positioned character and next input monad.
+-- Input depends on an internal state of the monad. The state must contain
+-- information that is necessary to track the current input position, which
+-- determines the next character to be read. The state must be updated as
+-- characters are read and the position is advanced.
 --
--- The monad may have side effects, but the same monad instance must yield the
--- same result for repeated reads. That is, the monad must be idempotent.
-newtype InputT m = InputT (m (Either Position (Positioned Char, InputT m)))
-
--- | @prepend cs m@ returns an input monad that first yields the elements of
--- @cs@ and then @m@.
-prepend :: Monad m => [Positioned Char] -> InputT m -> InputT m
-prepend [] m = m
-prepend (c:cs) m = InputT (return (Right (c, prepend cs m)))
-
--- | Monad transformer that manages input position as a state.
-type PositionT m = StateT (InputT m)
-
--- | Extension of 'MonadState' that allows character input operations.
-class MonadState (InputT n) m => MonadPosition n m where
-  -- | Returns the character at the current position without advancing the
-  -- position.
-  peekChar :: m (Either Position (Positioned Char))
-  -- | Reads one character at the current position and advancing the position
-  -- to the next character.
+-- The 'static' function may be used to rewind the position after some input
+-- is read. In this function, the state must be restored to indicate the
+-- position before the characters were read. Thereafter the same characters
+-- must be returned in subsequent read operations.
+--
+-- Reading a character may be an operation with a side effect. Such side
+-- effects must be encoded in the monad. When re-reading characters after the
+-- position was rewound, however, characters must be read without side
+-- effects. In other words, reading operations must be idempotent in terms of
+-- side effects.
+class Monad m => MonadInput m where
+  -- | Reads one character at the current position, advancing the position to
+  -- the next character. If the current position is end-of-input, the position
+  -- must not be changed and @Left position@ is returned.
   popChar :: m (Either Position (Positioned Char))
-  -- | Returns the result of the given parser without advancing the input
-  -- position.
-  followedBy :: m a -> m a
+  -- | Returns the result of the given monad but cancels any position update
+  -- that have occurred in the monad, i.e., the position is rewound to the
+  -- original.
+  static :: m a -> m a
+  -- | Returns the character at the current position without advancing the
+  -- position. The default implementation is @static popChar@.
+  peekChar :: m (Either Position (Positioned Char))
+  peekChar = static popChar
+  -- | Pushes the given characters into the current position. Subsequent reads
+  -- must first return the inserted characters and then return to the original
+  -- position, continuing to characters that would have been immediately read
+  -- if 'pushChars' was not used.
+  pushChars :: [Positioned Char] -> m ()
 
-instance Monad m => MonadPosition m (StateT (InputT m) m) where
-  peekChar = do
-    InputT i <- get
-    lift (fmap (fmap fst) i)
-  popChar = do
-    InputT i1 <- get
-    e <- lift i1
-    case e of
-      Left p -> return (Left p)
-      Right (c, i2) -> do
-        put i2
-        return (Right c)
-  followedBy m = do
-    i <- get
-    a <- m
-    put i
-    return a
-
-instance MonadPosition n m => MonadPosition n (ReaderT r m) where
-  peekChar = lift peekChar
-  popChar = lift popChar
-  followedBy = mapReaderT followedBy
+-- | Returns the current position.
+currentPosition :: MonadInput m => m Position
+currentPosition = either id fst <$> peekChar
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Syntax.hs
+++ b/src/Flesh/Language/Syntax.hs
@@ -1,0 +1,54 @@
+{-
+Copyright (C) 2017 WATANABE Yuki <magicant@wonderwand.net>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-}
+
+{-# LANGUAGE Safe #-}
+
+{-|
+Copyright   : (C) 2017 WATANABE Yuki
+License     : GPL-2
+Portability : portable
+
+This module defines the abstract syntax tree of the shell language.
+-}
+module Flesh.Language.Syntax (
+  DoubleQuoteUnit(..),
+  WordUnit(..)) where
+
+import qualified Data.List.NonEmpty as NE
+import Flesh.Source.Position
+
+-- | Element of double quotes.
+data DoubleQuoteUnit =
+    -- | Single bear character.
+    Char Char
+    -- | Character escaped by a backslash.
+    | Backslashed Char
+    -- | Parameter expansion.
+    | Parameter -- FIXME
+    | CommandSubstitution -- FIXME of the $(...) form
+    | Backquoted -- FIXME command substitution
+    | Arithmetic -- FIXME
+
+-- | Element of words.
+data WordUnit =
+    -- | Unquoted double-quote unit as a word unit.
+    Unquoted DoubleQuoteUnit
+    -- | Double-quote.
+    | DoubleQuote (NE.NonEmpty (Positioned DoubleQuoteUnit))
+    | SingleQuote -- FIXME Text
+
+-- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Source/Position.hs
+++ b/src/Flesh/Source/Position.hs
@@ -15,19 +15,21 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -}
 
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE Safe #-}
 
 {-|
 Copyright   : (C) 2017 WATANABE Yuki
 License     : GPL-2
-Portability : portable
+Portability : non-portable (flexible instances)
 
 This module defines elements for positioning source code characters and
 describing origin of them.
 -}
 module Flesh.Source.Position (
-    Situation(..), Fragment(..), Position(..), dummyPosition,
-    Positioned, next, spread) where
+    Situation(..), Fragment(..), Position(..), dummyPosition, next,
+    Positioned, PositionedList(..), PositionedString, unposition, spread)
+    where
 
 import qualified Flesh.Language.Alias.Core as Alias
 
@@ -93,16 +95,34 @@ dummyPosition :: String -> Position
 dummyPosition c = Position {fragment = f, index = 0}
   where f = Fragment {code = c, situation = StandardInput, lineNo = 0}
 
--- | Something with a record of position from which it originated.
-type Positioned a = (Position, a)
-
 -- | Increments the index of a position.
 next :: Position -> Position
 next (Position fragment_ index_) = Position fragment_ (index_ + 1)
 
+-- | Something with a record of position from which it originated.
+type Positioned a = (Position, a)
+
+-- | Like @['Positioned' a]@, but the last nil also has its position.
+data PositionedList a = Nil Position | (:~) (Positioned a) (PositionedList a)
+infixr 5 :~
+
+-- | Like @['Positioned' 'Char']@, but the last nil also has its position.
+type PositionedString = PositionedList Char
+
+-- | Converts @'PositionedList' a@ to @['Positioned' a]@ by ignoring the last
+-- position.
+unposition :: PositionedList a -> [Positioned a]
+unposition (Nil _) = []
+unposition (x :~ xs) = x : unposition xs
+
+instance Show (PositionedList Char) where
+  show s = show l
+    where l = snd $ unzip $ unposition s
+
 -- | Given a position for the first element of a list, returns a list of
 -- elements positioned successively.
-spread :: Position -> [a] -> [Positioned a]
-spread p = zip (iterate next p)
+spread :: Position -> [a] -> PositionedList a
+spread p [] = Nil p
+spread p (x:xs) = (p, x) :~ spread (next p) xs
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Source/Position.hs
+++ b/src/Flesh/Source/Position.hs
@@ -104,6 +104,7 @@ type Positioned a = (Position, a)
 
 -- | Like @['Positioned' a]@, but the last nil also has its position.
 data PositionedList a = Nil Position | (:~) (Positioned a) (PositionedList a)
+  deriving Eq
 infixr 5 :~
 
 -- | Like @['Positioned' 'Char']@, but the last nil also has its position.
@@ -115,7 +116,7 @@ unposition :: PositionedList a -> [Positioned a]
 unposition (Nil _) = []
 unposition (x :~ xs) = x : unposition xs
 
-instance Show (PositionedList Char) where
+instance Show a => Show (PositionedList a) where
   show s = show l
     where l = snd $ unzip $ unposition s
 


### PR DESCRIPTION
 - The `MonadInput` class is defined as well as a utility instance for `PositionedString`.
 - A basic parser combinators are defined for parsing some characters.
 - A minimal syntax of the shell langauge is defined. (Actually this is not (yet) relevant with the two above)

This is part of #4.