### PR TITLE
Reorganize definitions for input and error handling

### DIFF
--- a/hspec-src/Flesh/Language/Parser/ErrorSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/ErrorSpec.hs
@@ -73,6 +73,15 @@ run m = runState (runAttemptT m)
 
 spec :: Spec
 spec = do
+  describe "notFollowedBy" $ do
+    prop "succeeds if argument fails" $ \e i ->
+      let f = failureOfError e
+       in run (notFollowedBy f) i === run (return ()) i
+
+    prop "fails if argument succeeds" $ \v i ->
+      let _ = v :: Int
+       in run (notFollowedBy (return v)) i === run failure i
+
   describe "setReason" $ do
     prop "replaces UnknownReason" $ \s e ->
       let Error r p = e

--- a/hspec-src/Flesh/Language/Parser/ErrorSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/ErrorSpec.hs
@@ -73,25 +73,6 @@ run m = runState (runAttemptT m)
 
 spec :: Spec
 spec = do
-  describe "Alternative (AttemptT m) (<|>)" $ do
-    prop "returns hard errors intact" $ \e a i ->
-      let _ = a :: AttemptT Identity Int
-          a' = mapAttemptT (return . runIdentity) a
-          f  = failureOfError e
-       in run (f <|> a') i === run f i
-
-    prop "returns success intact" $ \v a i ->
-      let _ = a :: AttemptT Identity Int
-          a' = mapAttemptT (return . runIdentity) a
-          s  = return v
-       in run (s <|> a') i === run s i
-
-    prop "recovers soft errors" $ \e a i ->
-      let _ = a :: AttemptT Identity Int
-          a' = mapAttemptT (return . runIdentity) a
-          f  = try $ failureOfError e
-       in run (f <|> a') i === run a' i
-
   describe "setReason" $ do
     prop "replaces UnknownReason" $ \s e ->
       let Error r p = e
@@ -112,5 +93,24 @@ spec = do
     prop "retains successes and soft errors intact" $ \a ->
       let _ = a :: AttemptT Identity Int
        in not (isHardError a) ==> try a === a
+
+  describe "Alternative (AttemptT m) (<|>)" $ do
+    prop "returns hard errors intact" $ \e a i ->
+      let _ = a :: AttemptT Identity Int
+          a' = mapAttemptT (return . runIdentity) a
+          f  = failureOfError e
+       in run (f <|> a') i === run f i
+
+    prop "returns success intact" $ \v a i ->
+      let _ = a :: AttemptT Identity Int
+          a' = mapAttemptT (return . runIdentity) a
+          s  = return v
+       in run (s <|> a') i === run s i
+
+    prop "recovers soft errors" $ \e a i ->
+      let _ = a :: AttemptT Identity Int
+          a' = mapAttemptT (return . runIdentity) a
+          f  = try $ failureOfError e
+       in run (f <|> a') i === run a' i
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/hspec-src/Flesh/Language/Parser/ErrorSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/ErrorSpec.hs
@@ -92,7 +92,7 @@ spec = do
           f  = try $ failure e
        in run (f <|> a') i === run a' i
 
-  describe "MonadAttempt (AttemptT m) setReason" $ do
+  describe "setReason" $ do
     prop "replaces UnknownReason" $ \s e ->
       let Error r p = e
           a         = throwError (s, e) :: AttemptT Identity Int
@@ -103,7 +103,7 @@ spec = do
       not (isUnknownReason (a :: AttemptT Identity Int)) ==>
         setReason r a === a
 
-  describe "MonadAttempt (AttemptT m) try" $ do
+  describe "try" $ do
     prop "converts hard errors to soft" $ \e ->
       let h = throwError (Hard, e) :: AttemptT Identity Int
           s = throwError (Soft, e) :: AttemptT Identity Int

--- a/hspec-src/Flesh/Language/Parser/ErrorSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/ErrorSpec.hs
@@ -94,13 +94,14 @@ spec = do
 
   describe "MonadAttempt (AttemptT m) setReason" $ do
     prop "replaces UnknownReason" $ \s e ->
-      let a         = throwError (s, e) :: AttemptT Identity Int
-          Error _ p = e
-       in setReason e (throwError (s, Error UnknownReason p)) === a
+      let Error r p = e
+          a         = throwError (s, e) :: AttemptT Identity Int
+          a'        = throwError (s, Error UnknownReason p)
+       in setReason r a' === a
 
-    prop "retains known reason" $ \e a ->
+    prop "retains known reason" $ \r a ->
       not (isUnknownReason (a :: AttemptT Identity Int)) ==>
-        setReason e a === a
+        setReason r a === a
 
   describe "MonadAttempt (AttemptT m) try" $ do
     prop "converts hard errors to soft" $ \e ->

--- a/hspec-src/Flesh/Language/Parser/ErrorSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/ErrorSpec.hs
@@ -77,7 +77,7 @@ spec = do
     prop "returns hard errors intact" $ \e a i ->
       let _ = a :: AttemptT Identity Int
           a' = mapAttemptT (return . runIdentity) a
-          f  = failure e
+          f  = failureOfError e
        in run (f <|> a') i === run f i
 
     prop "returns success intact" $ \v a i ->
@@ -89,7 +89,7 @@ spec = do
     prop "recovers soft errors" $ \e a i ->
       let _ = a :: AttemptT Identity Int
           a' = mapAttemptT (return . runIdentity) a
-          f  = try $ failure e
+          f  = try $ failureOfError e
        in run (f <|> a') i === run a' i
 
   describe "setReason" $ do

--- a/src/Flesh/Language/Parser/Char.hs
+++ b/src/Flesh/Language/Parser/Char.hs
@@ -39,9 +39,9 @@ satisfy :: (MonadInput m, MonadError (Severity, Error) m)
 satisfy pred_ = do
   e <- popChar
   case e of
-    Left pos -> failure' pos
+    Left pos -> failureOfPosition pos
     Right pc@(pos, c) | pred_ c   -> return pc
-                      | otherwise -> failure' pos
+                      | otherwise -> failureOfPosition pos
 
 -- | Parses the given single character.
 --
@@ -71,6 +71,6 @@ eof = do
   e <- peekChar
   case e of
     Left pos -> return pos
-    Right (pos, _) -> failure' pos
+    Right (pos, _) -> failureOfPosition pos
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Parser/Char.hs
+++ b/src/Flesh/Language/Parser/Char.hs
@@ -15,12 +15,13 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -}
 
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE Safe #-}
 
 {-|
 Copyright   : (C) 2017 WATANABE Yuki
 License     : GPL-2
-Portability : portable
+Portability : non-portable (flexible contexts)
 
 This module defines character parsers.
 -}
@@ -33,7 +34,7 @@ import Flesh.Source.Position
 -- | Parses a single character that satisfies the given predicate.
 --
 -- Returns 'UnknownReason' on dissatisfaction.
-satisfy :: (MonadInput m, MonadAttempt m)
+satisfy :: (MonadInput m, MonadError (Severity, Error) m)
         => (Char -> Bool) -> m (Positioned Char)
 satisfy pred_ = do
   e <- popChar
@@ -45,24 +46,27 @@ satisfy pred_ = do
 -- | Parses the given single character.
 --
 -- Returns 'UnknownReason' on failure.
-char :: (MonadInput m, MonadAttempt m) => Char -> m (Positioned Char)
+char :: (MonadInput m, MonadError (Severity, Error) m)
+     => Char -> m (Positioned Char)
 char c = satisfy (c ==)
 
 -- | Parses any single character.
 --
 -- Returns 'UnknownReason' if there is no next character.
-anyChar :: (MonadInput m, MonadAttempt m) => m (Positioned Char)
+anyChar :: (MonadInput m, MonadError (Severity, Error) m)
+        => m (Positioned Char)
 anyChar = satisfy (const True)
 
 -- | Parses a sequence of characters.
 --
 -- Returns 'UnknownReason' on failure.
-string :: (MonadInput m, MonadAttempt m) => String -> m [Positioned Char]
+string :: (MonadInput m, MonadError (Severity, Error) m)
+       => String -> m [Positioned Char]
 string [] = return []
 string (c:cs) = (:) <$> char c <*> string cs
 
 -- | Parses the /end-of-file/.
-eof :: (MonadInput m, MonadAttempt m) => m Position
+eof :: (MonadInput m, MonadError (Severity, Error) m) => m Position
 eof = do
   e <- peekChar
   case e of

--- a/src/Flesh/Language/Parser/Char.hs
+++ b/src/Flesh/Language/Parser/Char.hs
@@ -31,17 +31,23 @@ import Flesh.Language.Parser.Error
 import Flesh.Language.Parser.Input
 import Flesh.Source.Position
 
+-- | Parses any single character.
+--
+-- Returns 'UnknownReason' if there is no next character.
+anyChar :: (MonadInput m, MonadError (Severity, Error) m)
+        => m (Positioned Char)
+anyChar = do
+  e <- popChar
+  case e of
+    Left pos -> failureOfPosition pos
+    Right pc -> return pc
+
 -- | Parses a single character that satisfies the given predicate.
 --
 -- Returns 'UnknownReason' on dissatisfaction.
 satisfy :: (MonadInput m, MonadError (Severity, Error) m)
         => (Char -> Bool) -> m (Positioned Char)
-satisfy pred_ = do
-  e <- popChar
-  case e of
-    Left pos -> failureOfPosition pos
-    Right pc@(pos, c) | pred_ c   -> return pc
-                      | otherwise -> failureOfPosition pos
+satisfy p = anyChar `satisfying` (p . snd)
 
 -- | Parses the given single character.
 --
@@ -49,13 +55,6 @@ satisfy pred_ = do
 char :: (MonadInput m, MonadError (Severity, Error) m)
      => Char -> m (Positioned Char)
 char c = satisfy (c ==)
-
--- | Parses any single character.
---
--- Returns 'UnknownReason' if there is no next character.
-anyChar :: (MonadInput m, MonadError (Severity, Error) m)
-        => m (Positioned Char)
-anyChar = satisfy (const True)
 
 -- | Parses a sequence of characters.
 --

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -142,7 +142,7 @@ instance MonadTrans AttemptT where
 
 instance MonadInput m => MonadInput (AttemptT m) where
   popChar = lift popChar
-  static = mapAttemptT static
+  followedBy = mapAttemptT followedBy
   peekChar = lift peekChar
   pushChars = lift <$> pushChars
 

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -32,7 +32,7 @@ module Flesh.Language.Parser.Error (
   -- * Basic types
   Reason(..), Error(..), Severity(..),
   -- * Utilities for 'MonadError'
-  MonadError(..), failureOfError, failure', recover, setReason, try,
+  MonadError(..), failureOfError, failureOfPosition, recover, setReason, try,
   -- * The 'AttemptT' monad transformer
   AttemptT(..), attempt, runAttemptT, mapAttemptT) where
 
@@ -66,8 +66,8 @@ failureOfError :: MonadError (Severity, Error) m => Error -> m a
 failureOfError e = throwError (Hard, e)
 
 -- | Failure of unknown reason.
-failure' :: MonadError (Severity, Error) m => P.Position -> m a
-failure' p = failureOfError (Error {reason = UnknownReason, position = p})
+failureOfPosition :: MonadError (Severity, Error) m => P.Position -> m a
+failureOfPosition p = failureOfError (Error UnknownReason p)
 
 -- | Recovers from an error. This is a simple wrapper around 'catchError' that
 -- ignores the error's 'Severity'.

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -33,7 +33,7 @@ module Flesh.Language.Parser.Error (
   Reason(..), Error(..), Severity(..),
   -- * Utilities for 'MonadError'
   MonadError(..), failureOfError, failureOfPosition, failure, satisfying,
-  recover, setReason, try,
+  notFollowedBy, recover, setReason, try,
   -- * The 'AttemptT' monad transformer
   AttemptT(..), attempt, runAttemptT, mapAttemptT) where
 
@@ -81,6 +81,12 @@ satisfying :: (MonadInput m, MonadError (Severity, Error) m)
 satisfying m p = do
   r <- m
   if p r then return r else failure
+
+-- | @notFollowedBy m@ succeeds if @m@ fails. If @m@ succeeds, it is
+-- equivalent to 'failure'.
+notFollowedBy :: (MonadInput m, MonadError (Severity, Error) m) => m a -> m ()
+notFollowedBy m =
+  join $ catchError (m >> return failure) (const $ return $ return ())
 
 -- | Recovers from an error. This is a simple wrapper around 'catchError' that
 -- ignores the error's 'Severity'.

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -32,7 +32,7 @@ module Flesh.Language.Parser.Error (
   -- * Basic types
   Reason(..), Error(..), Severity(..),
   -- * Utilities for 'MonadError'
-  MonadError(..), failure, failure', recover, setReason, try,
+  MonadError(..), failureOfError, failure', recover, setReason, try,
   -- * The 'AttemptT' monad transformer
   AttemptT(..), attempt, runAttemptT, mapAttemptT) where
 
@@ -62,12 +62,12 @@ data Severity =
   deriving (Eq, Show)
 
 -- | Returns a failed attempt with the given (hard) error.
-failure :: MonadError (Severity, Error) m => Error -> m a
-failure e = throwError (Hard, e)
+failureOfError :: MonadError (Severity, Error) m => Error -> m a
+failureOfError e = throwError (Hard, e)
 
 -- | Failure of unknown reason.
 failure' :: MonadError (Severity, Error) m => P.Position -> m a
-failure' p = failure (Error {reason = UnknownReason, position = p})
+failure' p = failureOfError (Error {reason = UnknownReason, position = p})
 
 -- | Recovers from an error. This is a simple wrapper around 'catchError' that
 -- ignores the error's 'Severity'.

--- a/src/Flesh/Language/Parser/Input.hs
+++ b/src/Flesh/Language/Parser/Input.hs
@@ -32,6 +32,7 @@ module Flesh.Language.Parser.Input (
   MonadInput(..), currentPosition) where
 
 import Flesh.Source.Position
+import Control.Monad.Except
 import Control.Monad.State.Strict
 
 -- | Monad for character input operations.
@@ -101,5 +102,11 @@ instance Monad m => MonadInput (StateT PositionedString m) where
   pushChars (c:cs) = do
     pushChars cs
     modify' (c :~)
+
+instance MonadInput m => MonadInput (ExceptT e m) where
+  popChar = lift popChar
+  followedBy = mapExceptT followedBy
+  peekChar = lift peekChar
+  pushChars = lift . pushChars
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Parser/Input.hs
+++ b/src/Flesh/Language/Parser/Input.hs
@@ -41,8 +41,8 @@ import Control.Monad.State.Strict
 -- determines the next character to be read. The state must be updated as
 -- characters are read and the position is advanced.
 --
--- The 'static' function may be used to rewind the position after some input
--- is read. In this function, the state must be restored to indicate the
+-- The 'followedBy' function may be used to rewind the position after some
+-- input is read. In this function, the state must be restored to indicate the
 -- position before the characters were read. Thereafter the same characters
 -- must be returned in subsequent read operations.
 --
@@ -59,11 +59,11 @@ class Monad m => MonadInput m where
   -- | Returns the result of the given monad but cancels any position update
   -- that have occurred in the monad, i.e., the position is rewound to the
   -- original.
-  static :: m a -> m a
+  followedBy :: m a -> m a
   -- | Returns the character at the current position without advancing the
-  -- position. The default implementation is @static popChar@.
+  -- position. The default implementation is @followedBy popChar@.
   peekChar :: m (Either Position (Positioned Char))
-  peekChar = static popChar
+  peekChar = followedBy popChar
   -- | Pushes the given characters into the current position. Subsequent reads
   -- must first return the inserted characters and then return to the original
   -- position, continuing to characters that would have been immediately read
@@ -85,7 +85,7 @@ instance Monad m => MonadInput (StateT PositionedString m) where
         put cs'
         return (Right c)
 
-  static m = do
+  followedBy m = do
     savedstate <- get
     result <- m
     put savedstate


### PR DESCRIPTION
 - `MonadAttempt` is removed in favor of `MonadError (Severity, Error)`.
 - Some functions are redefined and renamed.
