### PR TITLE
Introduce MonadParser class

### DIFF
--- a/hspec-src/Flesh/Language/Parser/ErrorSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/ErrorSpec.hs
@@ -32,7 +32,8 @@ import Test.Hspec.QuickCheck
 import Test.QuickCheck
 
 instance Arbitrary Reason where
-  arbitrary = elements [UnknownReason, SomeReason]
+  arbitrary =
+    elements [UnknownReason, UnclosedDoubleQuote, UnclosedSingleQuote]
 
 instance Arbitrary Error where
   arbitrary = do

--- a/hspec-src/Flesh/Language/Parser/ErrorSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/ErrorSpec.hs
@@ -44,7 +44,7 @@ instance Arbitrary Severity where
   arbitrary = elements [Hard, Soft]
 
 instance (MonadError (Severity, Error) m, Arbitrary a)
-    => Arbitrary (AttemptT m a) where
+    => Arbitrary (ParserT m a) where
   arbitrary = oneof [success_, failure_]
     where success_ = return <$> arbitrary
           failure_ = do
@@ -58,33 +58,33 @@ instance Arbitrary a => Arbitrary (PositionedList a) where
     xs <- arbitrary
     return $ spread (dummyPosition s) xs
 
-type AE = AttemptT (ExceptT (Severity, Error) Identity)
-type AES = AttemptT (ExceptT (Severity, Error) (State PositionedString))
+type AE = ParserT (ExceptT (Severity, Error) Identity)
+type AES = ParserT (ExceptT (Severity, Error) (State PositionedString))
 
 isUnknownReason :: AE a -> Bool
 isUnknownReason a =
-  case runIdentity $ runExceptT $ runAttemptT a of
+  case runIdentity $ runExceptT $ runParserT a of
     Left (_, Error UnknownReason _) -> True
     _                               -> False
 
 isHardError :: AE a -> Bool
 isHardError a =
-  case runIdentity $ runExceptT $ runAttemptT a of
+  case runIdentity $ runExceptT $ runParserT a of
     Left (Hard, _) -> True
     _              -> False
 
 isSoftError :: AE a -> Bool
 isSoftError a =
-  case runIdentity $ runExceptT $ runAttemptT a of
+  case runIdentity $ runExceptT $ runParserT a of
     Left (Soft, _) -> True
     _              -> False
 
 run :: AES a
     -> PositionedString -> (Either (Severity, Error) a, PositionedString)
-run = runState . runExceptT . runAttemptT
+run = runState . runExceptT . runParserT
 
 aesFromAE :: AE a -> AES a
-aesFromAE = AttemptT . mapExceptT (return . runIdentity) . runAttemptT
+aesFromAE = ParserT . mapExceptT (return . runIdentity) . runParserT
 
 spec :: Spec
 spec = do
@@ -128,7 +128,7 @@ spec = do
       let _ = a :: AE Int
        in not (isSoftError a) ==> require a === a
 
-  describe "Alternative (AttemptT m) (<|>)" $ do
+  describe "Alternative (ParserT m) (<|>)" $ do
     prop "returns hard errors intact" $ \e a i ->
       let _ = a :: AE Int
           a' = aesFromAE a

--- a/hspec-src/Flesh/Language/Parser/TestUtil.hs
+++ b/hspec-src/Flesh/Language/Parser/TestUtil.hs
@@ -29,11 +29,10 @@ import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck
 
-type Tester = ParserT
-  (StateT PositionedString (ExceptT (Severity, Error) Identity))
+type Tester = ParserT (StateT PositionedString (ExceptT Failure Identity))
 
 runTester :: Tester a -> PositionedString
-          -> Either (Severity, Error) (a, PositionedString)
+          -> Either Failure (a, PositionedString)
 runTester parser = runIdentity . runExceptT . runStateT (runParserT parser)
 
 -- | @expectSuccessEof consumed lookahead parser result@ runs the given

--- a/hspec-src/Flesh/Language/Parser/TestUtil.hs
+++ b/hspec-src/Flesh/Language/Parser/TestUtil.hs
@@ -29,12 +29,12 @@ import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck
 
-type Tester = AttemptT
+type Tester = ParserT
   (StateT PositionedString (ExceptT (Severity, Error) Identity))
 
 runTester :: Tester a -> PositionedString
           -> Either (Severity, Error) (a, PositionedString)
-runTester parser = runIdentity . runExceptT . runStateT (runAttemptT parser)
+runTester parser = runIdentity . runExceptT . runStateT (runParserT parser)
 
 -- | @expectSuccessEof consumed lookahead parser result@ runs the given
 -- @parser@ for the source code @consumed ++ lookahead@ and tests if the

--- a/src/Flesh/Language/Parser/Char.hs
+++ b/src/Flesh/Language/Parser/Char.hs
@@ -34,8 +34,7 @@ import Flesh.Source.Position
 -- | Parses any single character.
 --
 -- Returns 'UnknownReason' if there is no next character.
-anyChar :: (MonadInput m, MonadError (Severity, Error) m)
-        => m (Positioned Char)
+anyChar :: MonadParser m => m (Positioned Char)
 anyChar = do
   e <- popChar
   case e of
@@ -45,34 +44,30 @@ anyChar = do
 -- | Parses a single character that satisfies the given predicate.
 --
 -- Returns 'UnknownReason' on dissatisfaction.
-satisfy :: (MonadInput m, MonadError (Severity, Error) m)
-        => (Char -> Bool) -> m (Positioned Char)
+satisfy :: MonadParser m => (Char -> Bool) -> m (Positioned Char)
 satisfy p = anyChar `satisfying` (p . snd)
 
 -- | Parses the given single character.
 --
 -- Returns 'UnknownReason' on failure.
-char :: (MonadInput m, MonadError (Severity, Error) m)
-     => Char -> m (Positioned Char)
+char :: MonadParser m => Char -> m (Positioned Char)
 char c = satisfy (c ==)
 
 -- | Parses one of the given characters.
 --
 -- Returns 'UnknownReason' on failure.
-oneOfChars :: (MonadInput m, MonadError (Severity, Error) m)
-           => [Char] -> m (Positioned Char)
+oneOfChars :: MonadParser m => [Char] -> m (Positioned Char)
 oneOfChars cs = satisfy (flip elem cs)
 
 -- | Parses a sequence of characters.
 --
 -- Returns 'UnknownReason' on failure.
-string :: (MonadInput m, MonadError (Severity, Error) m)
-       => String -> m [Positioned Char]
+string :: MonadParser m => String -> m [Positioned Char]
 string [] = return []
 string (c:cs) = (:) <$> char c <*> string cs
 
 -- | Parses the /end-of-file/.
-eof :: (MonadInput m, MonadError (Severity, Error) m) => m Position
+eof :: MonadParser m => m Position
 eof = do
   e <- peekChar
   case e of

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -164,20 +164,13 @@ notFollowedBy m = do
   let m' = m >> return (failureOfPosition pos)
   join $ catchError m' (const $ return $ return ())
 
--- | Modifies the behavior of a monad in the 'Alternative' (and 'MonadPlus')
--- operations so that 'Hard' errors are not recovered by the '<|>' operation.
+-- | Monad wrapper that instantiates 'MonadParser' from 'MonadInput' and
+-- 'MonadError'.
 --
 -- As an instance of 'Functor', 'Foldable', 'Applicative' and 'Monad',
--- @AttemptT m@ behaves the same as the original monad @m@. The difference
--- between them lies in the implementation of 'Alternative'. @'Alternative'
--- ('ExceptT' e m)@ requires the error type @e@ to be a 'Monoid', but
--- 'AttemptT' does not. An error value of 'AttemptT' always denotes a single
--- error. For 'AttemptT', 'empty' is defined as 'failure', whose reason should
--- be set by 'setReason'. Errors in 'AttemptT' are categorized into two levels
--- of severity: 'Hard' and 'Soft'. The 'failure' function returns 'Soft'
--- errors, but they can be converted to 'Hard' errors by 'require'. Only
--- 'Soft' errors are recovered by the '<|>' operator, which helps returning
--- user-friendly error messages.
+-- @AttemptT m@ behaves the same as the original monad @m@. The 'Alternative'
+-- instance for @AttemptT@ is constructed from the 'MonadError' instance to
+-- obey the 'MonadParser' laws.
 newtype AttemptT m a = AttemptT (m a)
   deriving (Eq, Show)
 
@@ -245,5 +238,8 @@ instance (MonadInput m, MonadError (Severity, Error) m)
 
 instance (MonadInput m, MonadError (Severity, Error) m)
   => MonadPlus (AttemptT m)
+
+instance (MonadInput m, MonadError (Severity, Error) m)
+  => MonadParser (AttemptT m)
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -141,16 +141,13 @@ require m = catchError m (throwError . handle)
 class (MonadPlus m, MonadInput m, MonadError (Severity, Error) m)
     => MonadParser m
 
--- TODO Below functions should depend on MonadParser
-
 -- | Failure of unknown reason at the current position.
-failure :: (MonadInput m, MonadError (Severity, Error) m) => m a
+failure :: MonadParser m => m a
 failure = currentPosition >>= failureOfPosition
 
 -- | @satisfying m p@ behaves like @m@ but fails if the result of @m@ does not
 -- satisfy predicate @p@. This is analogous to @'flip' 'mfilter'@.
-satisfying :: (MonadInput m, MonadError (Severity, Error) m)
-           => m a -> (a -> Bool) -> m a
+satisfying :: MonadParser m => m a -> (a -> Bool) -> m a
 satisfying m p = do
   pos <- currentPosition
   r <- m
@@ -158,7 +155,7 @@ satisfying m p = do
 
 -- | @notFollowedBy m@ succeeds if @m@ fails. If @m@ succeeds, it is
 -- equivalent to 'failure'.
-notFollowedBy :: (MonadInput m, MonadError (Severity, Error) m) => m a -> m ()
+notFollowedBy :: MonadParser m => m a -> m ()
 notFollowedBy m = do
   pos <- currentPosition
   let m' = m >> return (failureOfPosition pos)

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -49,8 +49,7 @@ import qualified Flesh.Source.Position as P
 
 -- | Reason of a parse error.
 data Reason =
-  UnknownReason -- TODO TBD
-  | SomeReason -- ^ only for testing
+  UnknownReason -- ^ Default reason that should be replaced by 'setReason'.
   | UnclosedDoubleQuote
   | UnclosedSingleQuote
   deriving (Eq, Show)

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -35,6 +35,8 @@ module Flesh.Language.Parser.Error (
   -- * Utilities for 'MonadError'
   MonadError(..), failureOfError, failureOfPosition, failure, satisfying,
   notFollowedBy, manyTill, someTill, recover, setReason, try, require,
+  -- * The 'MonadParser' class
+  MonadParser,
   -- * The 'AttemptT' monad transformer
   AttemptT(..), runAttemptT, mapAttemptT) where
 
@@ -147,6 +149,18 @@ try m = catchError m (throwError . handle)
 require :: MonadError (Severity, Error) m => m a -> m a
 require m = catchError m (throwError . handle)
   where handle (_, e) = (Hard, e)
+
+-- | Collection of properties required for basic parser implementation.
+--
+-- @MonadParser@ is a subclass of the input and error handling monads,
+-- supporting the basic behavior of the parser. It is also an instance of
+-- 'Alternative' and 'MonadPlus', where
+--
+--  * 'empty' and 'mzero' are equal to 'failure'; and
+--  * '<|>' and 'mplus' behave like 'catchError' but they only catch 'Soft'
+--    failures.
+class (MonadPlus m, MonadInput m, MonadError (Severity, Error) m)
+    => MonadParser m
 
 -- | Modifies the behavior of a monad in the 'Alternative' (and 'MonadPlus')
 -- operations so that 'Hard' errors are not recovered by the '<|>' operation.


### PR DESCRIPTION
This is part of #4.

The MonadError and Alternative implementations should co-work to provide consistent error handling mechanisms. Together with MonadInput, they should be redefined as a single monad.