### PR TITLE
Test comment parser with right input

### DIFF
--- a/hspec-src/Flesh/Language/Parser/LexSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/LexSpec.hs
@@ -30,7 +30,7 @@ spec :: Spec
 spec = do
   describe "comment" $ do
     prop "fails if input does not start with #" $ \s ->
-      not ("#" `isPrefixOf` s) ==>
+      not ("#" `isPrefixOf` s) && not ("\\\n" `isPrefixOf` s) ==>
         let p = dummyPosition s
             s' = spread p s
          in runTester comment s' === Left (Soft, Error UnknownReason p)


### PR DESCRIPTION
The test was occasionally failing because of the missing condition to
filter the input string.

Fixes #12