### PR TITLE
Define here document parser type

### DIFF
--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 module Flesh.Language.Parser.SyntaxSpec (spec) where
 
+import Flesh.Language.Parser.Alias
 import Flesh.Language.Parser.Char
 import Flesh.Language.Parser.Error
 import Flesh.Language.Parser.Lex

--- a/src/Flesh/Language/Parser/Alias.hs
+++ b/src/Flesh/Language/Parser/Alias.hs
@@ -31,7 +31,7 @@ module Flesh.Language.Parser.Alias (
   -- * Context
   ContextT,
   -- * Alias substitution
-  substituteAlias) where
+  substituteAlias, reparse) where
 
 import Control.Monad.Reader
 import Control.Monad.Trans.Maybe
@@ -75,5 +75,16 @@ substituteAlias t = do
       pos = Position frag 0
       cs = unposition $ spread pos $ v
   pushChars cs
+
+-- | Modifies a parser so that it retries parsing while it is failing, that
+-- is, returning 'Nothing'. This function is mainly meant for retrying after
+-- alias substitution.
+reparse :: Monad m => m (Maybe a) -> m a
+reparse a = reparse_a
+  where reparse_a = do
+          m <- a
+          case m of
+            Nothing -> reparse_a
+            Just v -> return v
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Parser/HereDoc.hs
+++ b/src/Flesh/Language/Parser/HereDoc.hs
@@ -38,6 +38,8 @@ document contents after the entire source code was parsed and yields a final
 syntax tree.
 -}
 module Flesh.Language.Parser.HereDoc (
+  -- * Data types
+  Operator(..), Content,
   -- * Accumulator
   AccumT, yieldOperator, drainOperators, yieldContent, contents,
   -- * Filler
@@ -48,12 +50,21 @@ module Flesh.Language.Parser.HereDoc (
 
 import Control.Applicative
 import Control.Monad.State.Strict
+import Flesh.Language.Syntax
 
 -- | Here document redirection operator type.
-type Operator = () -- FIXME
+data Operator = Operator {
+  fd :: Int,
+  isTabbed :: Bool,
+  delimiter :: Token}
+  deriving (Eq)
+
+instance Show Operator where
+  showsPrec n o = showsPrec n (fd o) . (s ++) . showsPrec n (delimiter o)
+    where s = if isTabbed o then "<<-" else "<<"
 
 -- | Here document content type.
-type Content = () -- FIXME
+type Content = EWord
 
 -- | State monad transformer that is intended to be used as part of a parser
 -- monad.

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -32,7 +32,7 @@ module Flesh.Language.Parser.Syntax (
   backslashed, doubleQuoteUnit, doubleQuote, singleQuote, wordUnit, tokenTill,
   normalToken, aliasableToken,
   -- * Syntax
-  simpleCommand) where
+  simpleCommand, list) where
 
 import Control.Applicative
 import Control.Monad.Reader
@@ -126,5 +126,9 @@ simpleCommand = runMaybeT $ f <$> h <*> t
 -- TODO global aliases
 -- TODO assignments
 -- TODO Redirections
+
+-- | FIXME
+list :: (MonadParser m, MonadReader Alias.DefinitionSet m) => m Command
+list = reparse simpleCommand
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -32,7 +32,7 @@ module Flesh.Language.Parser.Syntax (
   backslashed, doubleQuoteUnit, doubleQuote, singleQuote, wordUnit, tokenTill,
   normalToken, aliasableToken,
   -- * Syntax
-  simpleCommand, reparse) where
+  simpleCommand) where
 
 import Control.Applicative
 import Control.Monad.Reader
@@ -126,16 +126,5 @@ simpleCommand = runMaybeT $ f <$> h <*> t
 -- TODO global aliases
 -- TODO assignments
 -- TODO Redirections
-
--- | Modifies a parser so that it retries parsing while it is failing, that
--- is, returning 'Nothing'. This function is mainly meant for retrying after
--- alias substitution.
-reparse :: Monad m => m (Maybe a) -> m a
-reparse a = reparse_a
-  where reparse_a = do
-          m <- a
-          case m of
-            Nothing -> reparse_a
-            Just v -> return v
 
 -- vim: set et sw=2 sts=2 tw=78:


### PR DESCRIPTION
This is part of #4.

 - Define type(s) for here document parsing
   - [x] Define `Operator` and `Content`.
   - [x] Define `MonadAccum` class and `AccumT` instances.
   - [x] Define `HereDocAliasT` as newtype & `MonadTrans`.
   - [ ] ~~Define `expectShowEofT` etc. which takes a `t Tester a` argument instead of `Tester a`.~~
   - [ ] ~~Use `expectShowEofT` to test `simpleCommand`.~~
 - Implement here-document parsing in `simpleCommand`.
   - [x] Move `reparse` to the alias module.
   - [x] Define `fill`.
   - [x] Define `list`.
   - [x] Redefine `simpleCommand` so that it returns `HereDocAliasT` type.