### PR TITLE
Parsing here documents

### DIFF
--- a/hspec-src/Flesh/Language/Parser/LexSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/LexSpec.hs
@@ -59,4 +59,37 @@ spec = do
     context "ignores line continuations in comment body" $ do
       expectSuccessEof "#\\" "\n" (fmap (fmap snd) comment) "\\"
 
+  describe "anyOperator" $ do
+    context "parses control operator" $ do
+      expectSuccessEof ";"  ""  (snd <$> anyOperator) ";"
+      expectSuccessEof ";"  "&" (snd <$> anyOperator) ";"
+      expectSuccess    ";;" ""  (snd <$> anyOperator) ";;"
+      expectSuccessEof "|"  ""  (snd <$> anyOperator) "|"
+      expectSuccessEof "|"  "&" (snd <$> anyOperator) "|"
+      expectSuccess    "||" ""  (snd <$> anyOperator) "||"
+      expectSuccessEof "&"  ""  (snd <$> anyOperator) "&"
+      expectSuccessEof "&"  "|" (snd <$> anyOperator) "&"
+      expectSuccess    "&&" ""  (snd <$> anyOperator) "&&"
+      expectSuccess    "("  ""  (snd <$> anyOperator) "("
+      expectSuccess    ")"  ""  (snd <$> anyOperator) ")"
+
+    context "parses redirection operator" $ do
+      expectSuccessEof "<"   ""  (snd <$> anyOperator) "<"
+      expectSuccessEof "<"   "-" (snd <$> anyOperator) "<"
+      expectSuccessEof "<"   "|" (snd <$> anyOperator) "<"
+      expectSuccessEof "<<"  ""  (snd <$> anyOperator) "<<"
+      expectSuccessEof "<<"  "|" (snd <$> anyOperator) "<<"
+      expectSuccess    "<<-" ""  (snd <$> anyOperator) "<<-"
+      expectSuccess    "<>"  ""  (snd <$> anyOperator) "<>"
+      expectSuccess    "<&"  ""  (snd <$> anyOperator) "<&"
+      expectSuccessEof ">"   ""  (snd <$> anyOperator) ">"
+      expectSuccessEof ">"   "-" (snd <$> anyOperator) ">"
+      expectSuccess    ">>"  ""  (snd <$> anyOperator) ">>"
+      expectSuccess    ">|"  ""  (snd <$> anyOperator) ">|"
+      expectSuccess    ">&"  ""  (snd <$> anyOperator) ">&"
+
+    context "skips line continuations" $ do
+      expectSuccessEof "\\\n&\\\n\\\n&"  "\\\n" (snd <$> anyOperator) "&&"
+      expectSuccessEof "\\\n<\\\n<\\\n-" "\\\n" (snd <$> anyOperator) "<<-"
+
 -- vim: set et sw=2 sts=2 tw=78:

--- a/hspec-src/Flesh/Language/Parser/LexSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/LexSpec.hs
@@ -92,4 +92,46 @@ spec = do
       expectSuccessEof "\\\n&\\\n\\\n&"  "\\\n" (snd <$> anyOperator) "&&"
       expectSuccessEof "\\\n<\\\n<\\\n-" "\\\n" (snd <$> anyOperator) "<<-"
 
+  describe "operator" $ do
+    context "parses argument control operator" $ do
+      expectSuccessEof ";"  ""  (snd <$> operator ";")  ";"
+      expectSuccessEof ";"  "&" (snd <$> operator ";")  ";"
+      expectSuccess    ";;" ""  (snd <$> operator ";;") ";;"
+      expectSuccessEof "|"  ""  (snd <$> operator "|")  "|"
+      expectSuccessEof "|"  "&" (snd <$> operator "|")  "|"
+      expectSuccess    "||" ""  (snd <$> operator "||") "||"
+      expectSuccessEof "&"  ""  (snd <$> operator "&")  "&"
+      expectSuccessEof "&"  "|" (snd <$> operator "&")  "&"
+      expectSuccess    "&&" ""  (snd <$> operator "&&") "&&"
+      expectSuccess    "("  ""  (snd <$> operator "(")  "("
+      expectSuccess    ")"  ""  (snd <$> operator ")")  ")"
+
+    context "parses argument redirection operator" $ do
+      expectSuccessEof "<"   ""  (snd <$> operator "<")   "<"
+      expectSuccessEof "<"   "-" (snd <$> operator "<")   "<"
+      expectSuccessEof "<"   "|" (snd <$> operator "<")   "<"
+      expectSuccessEof "<<"  ""  (snd <$> operator "<<")  "<<"
+      expectSuccessEof "<<"  "|" (snd <$> operator "<<")  "<<"
+      expectSuccess    "<<-" ""  (snd <$> operator "<<-") "<<-"
+      expectSuccess    "<>"  ""  (snd <$> operator "<>")  "<>"
+      expectSuccess    "<&"  ""  (snd <$> operator "<&")  "<&"
+      expectSuccessEof ">"   ""  (snd <$> operator ">")   ">"
+      expectSuccessEof ">"   "-" (snd <$> operator ">")   ">"
+      expectSuccess    ">>"  ""  (snd <$> operator ">>")  ">>"
+      expectSuccess    ">|"  ""  (snd <$> operator ">|")  ">|"
+      expectSuccess    ">&"  ""  (snd <$> operator ">&")  ">&"
+
+    context "rejects operator other than argument" $ do
+      expectFailureEof ";;"  (operator ";")  Soft UnknownReason 0
+      expectFailureEof "&&"  (operator "&")  Soft UnknownReason 0
+      expectFailureEof "||"  (operator "|")  Soft UnknownReason 0
+      expectFailureEof "<<"  (operator "<")  Soft UnknownReason 0
+      expectFailureEof "<<-" (operator "<")  Soft UnknownReason 0
+      expectFailureEof "<<-" (operator "<<") Soft UnknownReason 0
+      expectFailureEof "<>"  (operator "<<") Soft UnknownReason 0
+      expectFailureEof ">>"  (operator ">")  Soft UnknownReason 0
+      expectFailureEof ">|"  (operator ">")  Soft UnknownReason 0
+      expectFailureEof ">&"  (operator ">")  Soft UnknownReason 0
+      expectFailureEof "\\\n>&"  (operator ">")  Soft UnknownReason 2
+
 -- vim: set et sw=2 sts=2 tw=78:

--- a/hspec-src/Flesh/Language/Parser/LexSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/LexSpec.hs
@@ -134,4 +134,28 @@ spec = do
       expectFailureEof ">&"  (operator ">")  Soft UnknownReason 0
       expectFailureEof "\\\n>&"  (operator ">")  Soft UnknownReason 2
 
+  describe "ioNumber" $ do
+    context "parses digits followed by < or >" $ do
+      expectSuccessEof "1" "<" ioNumber 1
+      expectSuccessEof "20" ">" ioNumber 20
+      expectSuccessEof "123" ">" ioNumber 123
+      expectSuccessEof
+        "12345678901234567890123456789012345678900123456789012345678900"
+        ">" ioNumber (-1)
+
+    context "rejects non-digits" $ do
+      expectFailureEof "<" ioNumber Soft UnknownReason 0
+      expectFailureEof "a" ioNumber Soft UnknownReason 0
+      expectFailureEof " " ioNumber Soft UnknownReason 0
+
+    context "rejects digits not followed by < or >" $ do
+      expectFailureEof "0" ioNumber Soft UnknownReason 1
+      expectFailureEof "1-" ioNumber Soft UnknownReason 1
+      expectFailureEof "23 " ioNumber Soft UnknownReason 2
+
+    context "skips line continuations" $ do
+      expectSuccessEof "\\\n\\\n1" "<" ioNumber 1
+      expectSuccessEof "1" "\\\n\\\n<" ioNumber 1
+      expectFailureEof "1\\\n-" ioNumber Soft UnknownReason 3
+
 -- vim: set et sw=2 sts=2 tw=78:

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -132,6 +132,8 @@ spec = do
           e = runTester (reparse aliasableToken >> readAll) s'
        in fmap fst e `shouldBe` Right "--color"
 
+  describe "redirect" $ return () -- FIXME
+
   describe "simpleCommand" $ do
     let sc = runMaybeT $ fill $ runHereDocAliasT simpleCommand
 

--- a/src/Flesh/Language/Parser/Char.hs
+++ b/src/Flesh/Language/Parser/Char.hs
@@ -44,7 +44,7 @@ anyChar = do
 --
 -- Returns 'UnknownReason' on dissatisfaction.
 satisfy :: MonadParser m => (Char -> Bool) -> m (Positioned Char)
-satisfy p = anyChar `satisfying` (p . snd)
+satisfy = satisfying anyChar
 
 -- | Parses the given single character.
 --

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -148,11 +148,11 @@ failure = currentPosition >>= failureOfPosition
 
 -- | @satisfying m p@ behaves like @m@ but fails if the result of @m@ does not
 -- satisfy predicate @p@. This is analogous to @'flip' 'mfilter'@.
-satisfying :: MonadParser m => m a -> (a -> Bool) -> m a
+satisfying :: MonadParser m
+           => m (P.Positioned a) -> (a -> Bool) -> m (P.Positioned a)
 satisfying m p = do
-  pos <- currentPosition
-  r <- m
-  if p r then return r else failureOfPosition pos
+  posr@(pos, r) <- m
+  if p r then return posr else failureOfPosition pos
 
 -- | @notFollowedBy m@ succeeds if @m@ fails. If @m@ succeeds, it is
 -- equivalent to 'failure'.

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -36,7 +36,7 @@ module Flesh.Language.Parser.Error (
   MonadError(..), failureOfError, failureOfPosition, manyTill, someTill,
   recover, setReason, try, require,
   -- * The 'MonadParser' class
-  MonadParser, failure, satisfying, notFollowedBy,
+  MonadParser, failure, satisfying, notFollowedBy, some',
   -- * The 'ParserT' monad transformer
   ParserT(..), runParserT, mapParserT) where
 
@@ -161,6 +161,10 @@ notFollowedBy m = do
   pos <- currentPosition
   let m' = m >> return (failureOfPosition pos)
   join $ catchError m' (const $ return $ return ())
+
+-- | @some' a@ is like @some a@, but returns a NonEmpty list.
+some' :: MonadParser m => m a -> m (NE.NonEmpty a)
+some' a = (NE.:|) <$> a <*> many a
 
 -- | Monad wrapper that instantiates 'MonadParser' from 'MonadInput' and
 -- 'MonadError'.

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -53,6 +53,7 @@ data Reason =
   UnknownReason -- ^ Default reason that should be replaced by 'setReason'.
   | UnclosedDoubleQuote
   | UnclosedSingleQuote
+  | MissingRedirectionTarget
   deriving (Eq, Show)
 
 -- | Parse error description.

--- a/src/Flesh/Language/Parser/HereDoc.hs
+++ b/src/Flesh/Language/Parser/HereDoc.hs
@@ -42,7 +42,7 @@ syntax tree.
 -}
 module Flesh.Language.Parser.HereDoc (
   -- * Data types
-  Operator(..), Content,
+  Operator, Content,
   -- * Accumulator
   AccumState, MonadAccum(..), AccumT, runAccumT, mapAccumT,
   -- * Filler
@@ -59,15 +59,7 @@ import Control.Monad.Trans.Maybe
 import Flesh.Language.Syntax
 
 -- | Here document redirection operator type.
-data Operator = Operator {
-  fd :: Int,
-  isTabbed :: Bool,
-  delimiter :: Token}
-  deriving (Eq)
-
-instance Show Operator where
-  showsPrec n o = showsPrec n (fd o) . (s ++) . showsPrec n (delimiter o)
-    where s = if isTabbed o then "<<-" else "<<"
+type Operator = HereDocOp
 
 -- | Here document content type.
 type Content = EWord

--- a/src/Flesh/Language/Parser/HereDoc.hs
+++ b/src/Flesh/Language/Parser/HereDoc.hs
@@ -241,11 +241,12 @@ instance Monad m => Applicative (HereDocAliasT m) where
   HereDocAliasT a  *> HereDocAliasT b = HereDocAliasT (a  *> b)
   HereDocAliasT a <*  HereDocAliasT b = HereDocAliasT (a <*  b)
 
--- The context (Alternative m, Monad m) is not enough. HereDocT requires
--- (MonadPlus m) for it to be Alternative.
-instance MonadPlus m => Alternative (HereDocAliasT m) where
-  empty = HereDocAliasT empty
-  HereDocAliasT a <|> HereDocAliasT b = HereDocAliasT (a <|> b)
+instance (Alternative m, Monad m) => Alternative (HereDocAliasT m) where
+  empty = HereDocAliasT $ HereDocT $ lift $ lift empty
+  a <|> b = conceal $ liftA2 (<||>) (reveal a) (reveal b)
+    where reveal = runStateT . runAccumT . runHereDocT . runHereDocAliasT
+          conceal = HereDocAliasT . HereDocT . AccumT . StateT
+          MaybeT a' <||> MaybeT b' = MaybeT $ a' <|> b'
 
 instance MonadTrans HereDocAliasT where
   lift = HereDocAliasT . lift . lift

--- a/src/Flesh/Language/Parser/Lex.hs
+++ b/src/Flesh/Language/Parser/Lex.hs
@@ -26,7 +26,7 @@ This module defines utilities for lexical parsing that are specific to the
 shell language.
 -}
 module Flesh.Language.Parser.Lex (
-  lineContinuation, lc, blank, comment, whites, operatorChar, endOfToken)
+  lineContinuation, lc, blank, comment, whites, operatorStarter, endOfToken)
     where
 
 import Control.Applicative
@@ -72,17 +72,18 @@ comment = lc $ do
 whites :: MonadParser m => m (Maybe [Positioned Char])
 whites = many blank *> (Just <$> comment <|> return Nothing)
 
-operatorChars :: [Char]
-operatorChars = ";|&<>()"
+operatorStarters :: [Char]
+operatorStarters = ";|&<>()"
 
--- | Parses a single operator char, possibly preceded by line continuations.
-operatorChar :: MonadParser m => m (Positioned Char)
-operatorChar = lc $ oneOfChars operatorChars
+-- | Parses a single-character operator, possibly preceded by line
+-- continuations.
+operatorStarter :: MonadParser m => m (Positioned Char)
+operatorStarter = lc $ oneOfChars operatorStarters
 
 -- | Succeeds before an end-of-token character. Consumes line continuations
 -- but nothing else.
 endOfToken :: MonadParser m => m ()
 endOfToken = lc $ followedBy op <|> followedBy blank' <|> followedBy eof
-  where op = oneOfChars ('\n' : operatorChars)
+  where op = oneOfChars ('\n' : operatorStarters)
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Parser/Lex.hs
+++ b/src/Flesh/Language/Parser/Lex.hs
@@ -109,10 +109,6 @@ anyOperator = do
 -- | Parses the given single operator, possibly including line continuations.
 -- The argument operator must be one of the operators parsed by 'anyOperator'.
 operator :: MonadParser m => String -> m (Positioned String)
-operator expected = do
-  actual <- anyOperator
-  if snd actual == expected
-     then return actual
-     else failureOfPosition (fst actual)
+operator o = anyOperator `satisfying` (o ==)
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Parser/Lex.hs
+++ b/src/Flesh/Language/Parser/Lex.hs
@@ -27,7 +27,7 @@ shell language.
 -}
 module Flesh.Language.Parser.Lex (
   lineContinuation, lc, blank, comment, whites, operatorStarter, endOfToken,
-  anyOperator) where
+  anyOperator, operator) where
 
 import Control.Applicative
 import Data.Char
@@ -105,5 +105,14 @@ anyOperator = do
               return (p, [c1, c2])
            <|> return (p, ">")
     _ -> return (p, [c1])
+
+-- | Parses the given single operator, possibly including line continuations.
+-- The argument operator must be one of the operators parsed by 'anyOperator'.
+operator :: MonadParser m => String -> m (Positioned String)
+operator expected = do
+  actual <- anyOperator
+  if snd actual == expected
+     then return actual
+     else failureOfPosition (fst actual)
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Parser/Lex.hs
+++ b/src/Flesh/Language/Parser/Lex.hs
@@ -27,7 +27,7 @@ shell language.
 -}
 module Flesh.Language.Parser.Lex (
   lineContinuation, lc, blank, digit, comment, whites, operatorStarter,
-  endOfToken, anyOperator, operator, ioNumber) where
+  endOfToken, anyOperator, operator, redirectOperator, ioNumber) where
 
 import Control.Applicative
 import Data.Char
@@ -118,6 +118,14 @@ anyOperator = do
 -- The argument operator must be one of the operators parsed by 'anyOperator'.
 operator :: MonadParser m => String -> m (Positioned String)
 operator o = anyOperator `satisfying` (o ==)
+
+-- | Parses a single direction operator, possibly including line
+-- continuations.
+redirectOperator :: MonadParser m => m (Positioned String)
+redirectOperator = anyOperator `satisfying` isRedirect
+  where isRedirect ('<':_) = True
+        isRedirect ('>':_) = True
+        isRedirect _ = False
 
 -- | Parses an IO_NUMBER token.
 ioNumber :: MonadParser m => m Int

--- a/src/Flesh/Language/Parser/Lex.hs
+++ b/src/Flesh/Language/Parser/Lex.hs
@@ -26,11 +26,12 @@ This module defines utilities for lexical parsing that are specific to the
 shell language.
 -}
 module Flesh.Language.Parser.Lex (
-  lineContinuation, lc, blank, comment, whites, operatorStarter, endOfToken,
-  anyOperator, operator) where
+  lineContinuation, lc, blank, digit, comment, whites, operatorStarter,
+  endOfToken, anyOperator, operator, ioNumber) where
 
 import Control.Applicative
 import Data.Char
+import qualified Data.List.NonEmpty as NE
 import Flesh.Source.Position
 import Flesh.Language.Parser.Char
 import Flesh.Language.Parser.Error
@@ -57,6 +58,13 @@ blank' = satisfy isBlank
 -- characters.
 blank :: MonadParser m => m (Positioned Char)
 blank = lc blank'
+
+digit' :: MonadParser m => m (Positioned Char)
+digit' = satisfy isDigit
+
+-- | Parses a digit character, possibly preceded by line continuations.
+digit :: MonadParser m => m (Positioned Char)
+digit = lc digit'
 
 -- | Parses a comment, possibly preceded by line continuations.
 --
@@ -110,5 +118,19 @@ anyOperator = do
 -- The argument operator must be one of the operators parsed by 'anyOperator'.
 operator :: MonadParser m => String -> m (Positioned String)
 operator o = anyOperator `satisfying` (o ==)
+
+-- | Parses an IO_NUMBER token.
+ioNumber :: MonadParser m => m Int
+ioNumber = do
+  ds <- some' digit
+  let p = fst (NE.head ds)
+  case reads $ snd <$> NE.toList ds of
+    [(n, "")] ->
+      if n > toInteger (maxBound :: Int)
+         then return (-1)
+         else do
+           followedBy $ lc $ oneOfChars "<>"
+           return $ fromInteger n
+    _ -> failureOfPosition p
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -32,11 +32,14 @@ module Flesh.Language.Parser.Syntax (
   backslashed, doubleQuoteUnit, doubleQuote, singleQuote, wordUnit, tokenTill,
   normalToken, aliasableToken,
   -- * Syntax
+  redirect,
   simpleCommand, list) where
 
 import Control.Applicative
 import Control.Monad.Reader
 import Control.Monad.Trans.Maybe
+import Data.List
+import Data.Maybe
 import qualified Flesh.Language.Alias as Alias
 import Flesh.Language.Parser.Alias
 import Flesh.Language.Parser.Char
@@ -113,6 +116,40 @@ aliasableToken = do
    in fmap inv $ runMaybeT $ tt >>= substituteAlias
    -- TODO substitute the next token if the current substitute ends with a
    -- blank.
+
+-- | Parses a redirection operator (@io_redirect@) and returns the raw result.
+-- Skips trailing whitespaces.
+redirectBody :: MonadParser m
+             => m (Maybe Int, Positioned String, Token)
+redirectBody = liftA3 (,,) (optional ioNumber) redirectOperator
+  (whites *> require (setReason MissingRedirectionTarget normalToken))
+
+yieldHereDoc :: Monad m => HereDocOp -> AccumT m (Filler Redirection)
+yieldHereDoc op = do
+  yieldOperator op
+  return $ do
+    c <- popContent
+    return $ HereDoc op c
+
+-- | Parses a redirection operator (@io_redirect@). Skips trailing
+-- whitespaces.
+redirect :: MonadParser m => HereDocT m Redirection
+redirect = HereDocT $ do
+  (maybeFd, (_opPos, op), t) <- lift redirectBody
+  -- TODO define 0 and 1 as constants elsewhere
+  let defaultFd = if "<" `isPrefixOf` op then 0 else 1
+      fd' = fromMaybe defaultFd maybeFd
+  case op of
+    "<"  -> return $ return $ FileRedirection fd' -- TODO redirection type
+    "<>" -> return $ return $ FileRedirection fd' -- TODO redirection type
+    "<&" -> return $ return $ FileRedirection fd' -- TODO redirection type
+    ">"  -> return $ return $ FileRedirection fd' -- TODO redirection type
+    ">>" -> return $ return $ FileRedirection fd' -- TODO redirection type
+    ">|" -> return $ return $ FileRedirection fd' -- TODO redirection type
+    ">&" -> return $ return $ FileRedirection fd' -- TODO redirection type
+    "<<" -> yieldHereDoc $ HereDocOp fd' False t
+    "<<-" -> yieldHereDoc $ HereDocOp fd' True t
+    _ -> error $ "unexpected redirection operator " ++ op
 
 -- | Parses a simple command. Skips whitespaces after the command.
 simpleCommand :: (MonadParser m, MonadReader Alias.DefinitionSet m)


### PR DESCRIPTION
 - [x] Define here document redirection operator syntax.
 - [x] Define operator parser.
 - [x] Define `IO_NUMBER` parser.
 - [x] Define `io_here` parser.
 - [ ] Parse here-document contents after a newline.
 - [ ] Change the file descriptor type to `Integer` or `CInt`.
 - [ ] Save redirection operator position in `Redirection`.