### PR TITLE
Define AliasT monad transformer

### DIFF
--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -19,7 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 module Flesh.Language.Parser.SyntaxSpec (spec) where
 
-import Control.Monad.Trans.Maybe
 import Flesh.Language.Parser.Alias
 import Flesh.Language.Parser.Char
 import Flesh.Language.Parser.Error
@@ -133,7 +132,7 @@ spec = do
        in fmap fst e `shouldBe` Right "--color"
 
   describe "simpleCommand" $ do
-    let sc = runMaybeT $ fill $ runHereDocAliasT simpleCommand
+    let sc = runAliasT $ fill simpleCommand
 
     context "is some tokens" $ do
       expectShowEof "foo" "" sc "Just foo"

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -104,31 +104,33 @@ spec = do
         Soft UnknownReason 0
 
   describe "aliasableToken" $ do
+    let at = runAliasT aliasableToken
+
     context "returns unmatched token" $ do
-      expectShow "foo" ";" aliasableToken "Just foo"
+      expectShow "foo" ";" at "Just foo"
 
     context "returns quoted token" $ do
-      expectShow "f\\oo" ";" aliasableToken "Just f\\oo"
-      expectShow "f\"o\"o" "&" aliasableToken "Just f\"o\"o"
-      expectShow "f'o'o" ")" aliasableToken "Just f'o'o"
+      expectShow "f\\oo" ";" at "Just f\\oo"
+      expectShow "f\"o\"o" "&" at "Just f\"o\"o"
+      expectShow "f'o'o" ")" at "Just f'o'o"
 
     context "returns non-constant token" $ do
-      expectShow "f${1}o" ";" aliasableToken "Just f${1}o"
+      expectShow "f${1}o" ";" at "Just f${1}o"
 
     context "modifies pending input" $ do
-      expectSuccessEof defaultAliasName "" (aliasableToken >> readAll) $
+      expectSuccessEof defaultAliasName "" (at >> readAll) $
         defaultAliasValue
 
     it "returns nothing after substitution" $
       let s = defaultAliasName
           s' = spread (dummyPosition s) s
-          e = runTester aliasableToken s'
+          e = runTester at s'
        in fmap fst e `shouldBe` Right Nothing
 
     it "stops on recursion" $
       let s = defaultAliasName
           s' = spread (dummyPosition s) s
-          e = runTester (reparse aliasableToken >> readAll) s'
+          e = runTester (reparse at >> readAll) s'
        in fmap fst e `shouldBe` Right "--color"
 
   describe "simpleCommand" $ do

--- a/src/Flesh/Language/Parser/Alias.hs
+++ b/src/Flesh/Language/Parser/Alias.hs
@@ -16,7 +16,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -}
 
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE Safe #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {-|
 Copyright   : (C) 2017 WATANABE Yuki
@@ -31,18 +34,100 @@ module Flesh.Language.Parser.Alias (
   -- * Context
   ContextT,
   -- * Alias substitution
-  substituteAlias, reparse) where
+  AliasT(..), mapAliasT, toMaybeT, fromMaybeT, substituteAlias, reparse) where
 
+import Control.Applicative
 import Control.Monad.Reader
 import Control.Monad.Trans.Maybe
 import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import Flesh.Language.Alias
+import Flesh.Language.Parser.Error
 import Flesh.Language.Parser.Input
 import Flesh.Source.Position
 
 -- | Monad transformer that makes parse results depend on alias definitions.
 type ContextT = ReaderT DefinitionSet
+
+-- | Monad transformer that represents results of parse that may be
+-- interrupted by alias substitution.
+--
+-- If alias substitution occurs on the first token in the parser, the result
+-- will be 'Nothing' and the parser must be applied again.
+--
+-- | The '<*>' and '>>= operators for 'AliasT' behave differently from those
+-- of 'MaybeT'. They try to re-parse the right hand side if it returned
+-- 'Nothing' and the left hand side consumed any input characters. In other
+-- words, the right hand side is implicitly re-parsed if the left hand side
+-- was successfully parsed as a non-empty non-terminal.
+newtype AliasT m a = AliasT {runAliasT :: m (Maybe a)}
+
+mapAliasT :: (m (Maybe a) -> n (Maybe b)) -> AliasT m a -> AliasT n b
+mapAliasT f = AliasT . f . runAliasT
+
+-- | Converts a 'AliasT' monad to a 'MaybeT' monad.
+toMaybeT :: AliasT m a -> MaybeT m a
+toMaybeT = MaybeT . runAliasT
+
+-- | Converts a 'MaybeT' monad to a 'AliasT' monad.
+fromMaybeT :: MaybeT m a -> AliasT m a
+fromMaybeT = AliasT . runMaybeT
+
+instance MonadTrans AliasT where
+  lift = AliasT . fmap Just
+
+instance Functor m => Functor (AliasT m) where
+  fmap f = mapAliasT $ fmap $ fmap f
+
+instance MonadParser m => Applicative (AliasT m) where
+  pure = AliasT . pure . Just
+  af <*> ax = AliasT $ do
+    p1 <- currentPosition
+    mf <- runAliasT af
+    case mf of
+      Nothing -> pure Nothing
+      Just f -> do
+        p2 <- currentPosition
+        let parseRhs = do
+              mx <- runAliasT ax
+              case mx of
+                Nothing -> if p1 == p2 then pure Nothing else parseRhs
+                Just x -> pure $ Just $ f x
+         in parseRhs
+
+instance MonadParser m => Alternative (AliasT m) where
+  empty = lift empty
+  a <|> b = AliasT $ runAliasT a <|> runAliasT b
+
+instance MonadParser m => Monad (AliasT m) where
+  return = pure
+  ax >>= af = AliasT $ do
+    p1 <- currentPosition
+    mx <- runAliasT ax
+    case mx of
+      Nothing -> return Nothing
+      Just x -> do
+        p2 <- currentPosition
+        let parseRhs = do
+              mb <- runAliasT $ af x
+              case mb of
+                Nothing -> if p1 == p2 then pure Nothing else parseRhs
+                Just b -> pure $ Just b
+         in parseRhs
+
+instance MonadParser m => MonadPlus (AliasT m)
+
+instance MonadParser m => MonadInput (AliasT m) where
+  popChar = lift popChar
+  lookahead = mapAliasT lookahead
+  peekChar = lift peekChar
+  pushChars = lift . pushChars
+
+instance (MonadParser m, MonadError e m) => MonadError e (AliasT m) where
+  throwError = lift . throwError
+  catchError m f = AliasT $ catchError (runAliasT m) (runAliasT . f)
+
+instance MonadParser m => MonadParser (AliasT m)
 
 -- | Returns 'True' iff the given position is applicable for alias
 -- substitution of the given name. The name is not applicable if the current

--- a/src/Flesh/Language/Parser/Alias.hs
+++ b/src/Flesh/Language/Parser/Alias.hs
@@ -153,6 +153,9 @@ substituteAlias t = do
   defs <- ask
   def <- MaybeT $ return $ M.lookup t defs
   pos' <- currentPosition
+  -- FIXME @applicable t pos'@ is not the correct test for recursive
+  -- substitution. The position of the substituted text should be tested but
+  -- @pos'@ is /after/ the text.
   guard $ applicable t pos'
   let a = Alias pos' def
       v = T.unpack $ value def

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -105,11 +105,10 @@ normalToken :: MonadParser m => m Token
 normalToken = tokenTill endOfToken <* whites
 
 -- | Like 'normalToken', but tries to perform alias substitution on the
--- result. If alias substitution was successful, this parser returns
--- 'Nothing'.
+-- result.
 aliasableToken :: (MonadParser m, MonadReader Alias.DefinitionSet m)
-               => m (Maybe Token)
-aliasableToken = do
+               => AliasT m Token
+aliasableToken = AliasT $ do
   t <- normalToken
   let inv Nothing = Just t
       inv (Just ()) = Nothing
@@ -123,7 +122,7 @@ simpleCommand :: (MonadParser m, MonadReader Alias.DefinitionSet m)
               => HereDocAliasT m Command
 simpleCommand = lift $ f <$> h <*> t
   where f h' t' = SimpleCommand (h':t') [] []
-        h = AliasT aliasableToken
+        h = aliasableToken
         t = lift (many normalToken)
 -- TODO global aliases
 -- TODO assignments

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -28,6 +28,7 @@ tree, error, and warnings.
 -}
 module Flesh.Language.Parser.Syntax (
   module Flesh.Language.Syntax,
+  HereDocAliasT,
   -- * Tokens
   backslashed, doubleQuoteUnit, doubleQuote, singleQuote, wordUnit, tokenTill,
   normalToken, aliasableToken,
@@ -45,6 +46,9 @@ import Flesh.Language.Parser.HereDoc
 import Flesh.Language.Parser.Lex
 import Flesh.Language.Syntax
 import Flesh.Source.Position
+
+-- | Combination of 'HereDocT' and 'AliasT'.
+type HereDocAliasT m a = HereDocT (AliasT m) a
 
 -- | Parses a backslash-escaped character that is parsed by the given parser.
 backslashed :: MonadParser m
@@ -117,9 +121,9 @@ aliasableToken = do
 -- | Parses a simple command. Skips whitespaces after the command.
 simpleCommand :: (MonadParser m, MonadReader Alias.DefinitionSet m)
               => HereDocAliasT m Command
-simpleCommand = HereDocAliasT $ lift $ f <$> h <*> t
+simpleCommand = lift $ f <$> h <*> t
   where f h' t' = SimpleCommand (h':t') [] []
-        h = MaybeT aliasableToken
+        h = AliasT aliasableToken
         t = lift (many normalToken)
 -- TODO global aliases
 -- TODO assignments
@@ -127,6 +131,6 @@ simpleCommand = HereDocAliasT $ lift $ f <$> h <*> t
 
 -- | FIXME
 list :: (MonadParser m, MonadReader Alias.DefinitionSet m) => m Command
-list = reparse $ runMaybeT $ fill $ runHereDocAliasT simpleCommand
+list = reparse $ runAliasT $ fill simpleCommand
 
 -- vim: set et sw=2 sts=2 tw=78:


### PR DESCRIPTION
 - [x] Define `AliasT` monad transformer
 - [x] Re-define `HereDocAliasT` using `AliasT`
 - ~~[ ] Re-define `substituteAlias` using `AliasT`~~
 - [x] Re-define `aliasableToken` using `AliasT`
 - ~~[ ] Define `MonadAlias` class~~