### PR TITLE
Parsing here documents

### DIFF
--- a/hspec-src/Flesh/Language/Parser/LexSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/LexSpec.hs
@@ -59,4 +59,37 @@ spec = do
     context "ignores line continuations in comment body" $ do
       expectSuccessEof "#\\" "\n" (fmap (fmap snd) comment) "\\"
 
+  describe "anyOperator" $ do
+    context "parses control operator" $ do
+      expectSuccessEof ";"  ""  (snd <$> anyOperator) ";"
+      expectSuccessEof ";"  "&" (snd <$> anyOperator) ";"
+      expectSuccess    ";;" ""  (snd <$> anyOperator) ";;"
+      expectSuccessEof "|"  ""  (snd <$> anyOperator) "|"
+      expectSuccessEof "|"  "&" (snd <$> anyOperator) "|"
+      expectSuccess    "||" ""  (snd <$> anyOperator) "||"
+      expectSuccessEof "&"  ""  (snd <$> anyOperator) "&"
+      expectSuccessEof "&"  "|" (snd <$> anyOperator) "&"
+      expectSuccess    "&&" ""  (snd <$> anyOperator) "&&"
+      expectSuccess    "("  ""  (snd <$> anyOperator) "("
+      expectSuccess    ")"  ""  (snd <$> anyOperator) ")"
+
+    context "parses redirection operator" $ do
+      expectSuccessEof "<"   ""  (snd <$> anyOperator) "<"
+      expectSuccessEof "<"   "-" (snd <$> anyOperator) "<"
+      expectSuccessEof "<"   "|" (snd <$> anyOperator) "<"
+      expectSuccessEof "<<"  ""  (snd <$> anyOperator) "<<"
+      expectSuccessEof "<<"  "|" (snd <$> anyOperator) "<<"
+      expectSuccess    "<<-" ""  (snd <$> anyOperator) "<<-"
+      expectSuccess    "<>"  ""  (snd <$> anyOperator) "<>"
+      expectSuccess    "<&"  ""  (snd <$> anyOperator) "<&"
+      expectSuccessEof ">"   ""  (snd <$> anyOperator) ">"
+      expectSuccessEof ">"   "-" (snd <$> anyOperator) ">"
+      expectSuccess    ">>"  ""  (snd <$> anyOperator) ">>"
+      expectSuccess    ">|"  ""  (snd <$> anyOperator) ">|"
+      expectSuccess    ">&"  ""  (snd <$> anyOperator) ">&"
+
+    context "skips line continuations" $ do
+      expectSuccessEof "\\\n&\\\n\\\n&"  "\\\n" (snd <$> anyOperator) "&&"
+      expectSuccessEof "\\\n<\\\n<\\\n-" "\\\n" (snd <$> anyOperator) "<<-"
+
 -- vim: set et sw=2 sts=2 tw=78:

--- a/hspec-src/Flesh/Language/Parser/LexSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/LexSpec.hs
@@ -92,4 +92,46 @@ spec = do
       expectSuccessEof "\\\n&\\\n\\\n&"  "\\\n" (snd <$> anyOperator) "&&"
       expectSuccessEof "\\\n<\\\n<\\\n-" "\\\n" (snd <$> anyOperator) "<<-"
 
+  describe "operator" $ do
+    context "parses argument control operator" $ do
+      expectSuccessEof ";"  ""  (snd <$> operator ";")  ";"
+      expectSuccessEof ";"  "&" (snd <$> operator ";")  ";"
+      expectSuccess    ";;" ""  (snd <$> operator ";;") ";;"
+      expectSuccessEof "|"  ""  (snd <$> operator "|")  "|"
+      expectSuccessEof "|"  "&" (snd <$> operator "|")  "|"
+      expectSuccess    "||" ""  (snd <$> operator "||") "||"
+      expectSuccessEof "&"  ""  (snd <$> operator "&")  "&"
+      expectSuccessEof "&"  "|" (snd <$> operator "&")  "&"
+      expectSuccess    "&&" ""  (snd <$> operator "&&") "&&"
+      expectSuccess    "("  ""  (snd <$> operator "(")  "("
+      expectSuccess    ")"  ""  (snd <$> operator ")")  ")"
+
+    context "parses argument redirection operator" $ do
+      expectSuccessEof "<"   ""  (snd <$> operator "<")   "<"
+      expectSuccessEof "<"   "-" (snd <$> operator "<")   "<"
+      expectSuccessEof "<"   "|" (snd <$> operator "<")   "<"
+      expectSuccessEof "<<"  ""  (snd <$> operator "<<")  "<<"
+      expectSuccessEof "<<"  "|" (snd <$> operator "<<")  "<<"
+      expectSuccess    "<<-" ""  (snd <$> operator "<<-") "<<-"
+      expectSuccess    "<>"  ""  (snd <$> operator "<>")  "<>"
+      expectSuccess    "<&"  ""  (snd <$> operator "<&")  "<&"
+      expectSuccessEof ">"   ""  (snd <$> operator ">")   ">"
+      expectSuccessEof ">"   "-" (snd <$> operator ">")   ">"
+      expectSuccess    ">>"  ""  (snd <$> operator ">>")  ">>"
+      expectSuccess    ">|"  ""  (snd <$> operator ">|")  ">|"
+      expectSuccess    ">&"  ""  (snd <$> operator ">&")  ">&"
+
+    context "rejects operator other than argument" $ do
+      expectFailureEof ";;"  (operator ";")  Soft UnknownReason 0
+      expectFailureEof "&&"  (operator "&")  Soft UnknownReason 0
+      expectFailureEof "||"  (operator "|")  Soft UnknownReason 0
+      expectFailureEof "<<"  (operator "<")  Soft UnknownReason 0
+      expectFailureEof "<<-" (operator "<")  Soft UnknownReason 0
+      expectFailureEof "<<-" (operator "<<") Soft UnknownReason 0
+      expectFailureEof "<>"  (operator "<<") Soft UnknownReason 0
+      expectFailureEof ">>"  (operator ">")  Soft UnknownReason 0
+      expectFailureEof ">|"  (operator ">")  Soft UnknownReason 0
+      expectFailureEof ">&"  (operator ">")  Soft UnknownReason 0
+      expectFailureEof "\\\n>&"  (operator ">")  Soft UnknownReason 2
+
 -- vim: set et sw=2 sts=2 tw=78:

--- a/hspec-src/Flesh/Language/Parser/LexSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/LexSpec.hs
@@ -28,6 +28,10 @@ import Test.QuickCheck
 
 spec :: Spec
 spec = do
+  describe "blank" $ do
+    context "does not accept newline" $ do
+      expectFailureEof "\n" blank Soft UnknownReason 0
+
   describe "comment" $ do
     prop "fails if input does not start with #" $ \s ->
       not ("#" `isPrefixOf` s) && not ("\\\n" `isPrefixOf` s) ==>
@@ -58,6 +62,10 @@ spec = do
 
     context "ignores line continuations in comment body" $ do
       expectSuccessEof "#\\" "\n" (fmap (fmap snd) comment) "\\"
+
+  describe "whites" $ do
+    context "does not skip newline" $ do
+      expectSuccessEof "" "\n" ("" <$ whites) ""
 
   describe "anyOperator" $ do
     context "parses control operator" $ do

--- a/hspec-src/Flesh/Language/Parser/LexSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/LexSpec.hs
@@ -134,4 +134,28 @@ spec = do
       expectFailureEof ">&"  (operator ">")  Soft UnknownReason 0
       expectFailureEof "\\\n>&"  (operator ">")  Soft UnknownReason 2
 
+  describe "ioNumber" $ do
+    context "parses digits followed by < or >" $ do
+      expectSuccessEof "1" "<" ioNumber 1
+      expectSuccessEof "20" ">" ioNumber 20
+      expectSuccessEof "123" ">" ioNumber 123
+      expectSuccessEof
+        "12345678901234567890123456789012345678900123456789012345678900"
+        ">" ioNumber (-1)
+
+    context "rejects non-digits" $ do
+      expectFailureEof "<" ioNumber Soft UnknownReason 0
+      expectFailureEof "a" ioNumber Soft UnknownReason 0
+      expectFailureEof " " ioNumber Soft UnknownReason 0
+
+    context "rejects digits not followed by < or >" $ do
+      expectFailureEof "0" ioNumber Soft UnknownReason 1
+      expectFailureEof "1-" ioNumber Soft UnknownReason 1
+      expectFailureEof "23 " ioNumber Soft UnknownReason 2
+
+    context "skips line continuations" $ do
+      expectSuccessEof "\\\n\\\n1" "<" ioNumber 1
+      expectSuccessEof "1" "\\\n\\\n<" ioNumber 1
+      expectFailureEof "1\\\n-" ioNumber Soft UnknownReason 3
+
 -- vim: set et sw=2 sts=2 tw=78:

--- a/hspec-src/Flesh/Language/Parser/LexSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/LexSpec.hs
@@ -147,9 +147,6 @@ spec = do
       expectSuccessEof "1" "<" ioNumber 1
       expectSuccessEof "20" ">" ioNumber 20
       expectSuccessEof "123" ">" ioNumber 123
-      expectSuccessEof
-        "12345678901234567890123456789012345678900123456789012345678900"
-        ">" ioNumber (-1)
 
     context "rejects non-digits" $ do
       expectFailureEof "<" ioNumber Soft UnknownReason 0

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -158,11 +158,15 @@ spec = do
     -- TODO it "accumulates result" pending
 
   describe "pendingHereDocContents" $ do
-    it "parses 1 pending content" pending -- FIXME
+    context "parses 1 pending content" $ do
+      expectShow "<<A\nA\n" "" completeLine "0<<A"
 
-    it "parses 2 pending contents" pending -- FIXME
+    context "parses 2 pending contents" $ do
+      expectShow "<<A 1<<B\nA\nB\n" "" completeLine "0<<A 1<<B"
 
-    it "leaves no pending contents" pending -- FIXME
+    context "leaves no pending contents" $ return ()
+    -- Nothing to test here because 'completeLine' would fail if any contents
+    -- are left pending.
 
   describe "newlineHD" $ do
     it "parses newline" pending -- FIXME

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -133,6 +133,8 @@ spec = do
           e = runTester (reparse at >> readAll) s'
        in fmap fst e `shouldBe` Right "--color"
 
+  describe "redirect" $ return () -- FIXME
+
   describe "simpleCommand" $ do
     let sc = runAliasT $ fill simpleCommand
 

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -198,11 +198,26 @@ spec = do
         "Just foo " ++ defaultAliasName
 
   describe "completeLine" $ do
-    xcontext "can be empty" $ do -- TODO
-      expectShow "\n" "" completeLine ""
+    {- TODO context "can be empty" $ do
+      expectShow "\n" "" completeLine "" -}
 
-    it "reparses alias" pending -- FIXME
+    context "reparses alias" $ do
+      expectShowEof (defaultAliasName ++ "\n") "" completeLine
+        defaultAliasValue
 
-    it "fills here document content" pending -- FIXME
+    it "fills empty here document content" $
+      let s = "<<X\nX\n"
+          s' = spread (dummyPosition s) s
+          f [SimpleCommand [] [] [(_, HereDoc _ c)]] = Just c
+          f _ = Nothing
+          e = runTester (f <$> completeLine) s'
+       in fmap fst e `shouldBe` Right (Just (EWord []))
+
+    -- TODO it "fills non-empty here document content" pending
+
+    it "fails with missing here doc contents" pending
+
+    context "may end with EOF with no here doc contents pending" $ do
+      expectShowEof "foo bar" "" completeLine "foo bar"
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -130,7 +130,7 @@ spec = do
     it "stops on recursion" $
       let s = defaultAliasName
           s' = spread (dummyPosition s) s
-          e = runTester (reparse at >> readAll) s'
+          e = runTester (reparse aliasableToken >> readAll) s'
        in fmap fst e `shouldBe` Right "--color"
 
   describe "redirect" $ return () -- FIXME

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -147,9 +147,12 @@ spec = do
       expectShow "<<-X\n\t\t\tX\n" "" completeLine "0<<-X"
 
   describe "hereDocContent" $ do
-    it "ends with delimiter" pending -- FIXME
+    context "ends with delimiter" $ do
+      expectShow "<<-X\nX\n" "" completeLine "0<<-X"
+      expectFailureEof "<<-X\nfoo\n" completeLine
+        Hard UnclosedHereDocContent 5
 
-    it "accumulates result" pending -- FIXME
+    -- TODO it "accumulates result" pending
 
   describe "pendingHereDocContents" $ do
     it "parses 1 pending content" pending -- FIXME

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -136,11 +136,15 @@ spec = do
   describe "redirect" $ return () -- FIXME
 
   describe "hereDocDelimiter" $ do
-    it "is a token followed by a newline" pending -- FIXME
+    context "is a token followed by a newline" $ do
+      expectShow "<<X\nX\n" "" completeLine "0<<X"
 
-    it "matches an unquoted token" pending -- FIXME
+    -- TODO it "matches an unquoted token" pending
 
-    it "can be indented for <<-" pending -- FIXME
+    context "can be indented for <<-" $ do
+      expectShow "<<-X\nX\n"       "" completeLine "0<<-X"
+      expectShow "<<-X\n\tX\n"     "" completeLine "0<<-X"
+      expectShow "<<-X\n\t\t\tX\n" "" completeLine "0<<-X"
 
   describe "hereDocContent" $ do
     it "ends with delimiter" pending -- FIXME
@@ -181,6 +185,9 @@ spec = do
         "Just foo " ++ defaultAliasName
 
   describe "completeLine" $ do
+    xcontext "can be empty" $ do -- TODO
+      expectShow "\n" "" completeLine ""
+
     it "reparses alias" pending -- FIXME
 
     it "fills here document content" pending -- FIXME

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -201,7 +201,7 @@ spec = do
         defaultAliasValue
 
     it "fills empty here document content" $
-      let f [SimpleCommand [] [] [(_, HereDoc _ c)]] = Just c
+      let f [SimpleCommand [] [] [HereDoc _ c]] = Just c
           f _ = Nothing
           e = runTesterWithDummyPositions (f <$> completeLine) "<<X\nX\n"
        in fmap fst e `shouldBe` Right (Just (EWord []))

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 module Flesh.Language.Parser.SyntaxSpec (spec) where
 
+import Data.List.NonEmpty (NonEmpty(..))
 import Flesh.Language.Parser.Alias
 import Flesh.Language.Parser.Char
 import Flesh.Language.Parser.Error
@@ -215,7 +216,11 @@ spec = do
 
     -- TODO it "fills non-empty here document content" pending
 
-    it "fails with missing here doc contents" pending
+    context "fails with missing here doc contents" $ do
+      let isExpectedReason (MissingHereDocContents
+            (HereDocOp 0 False d :| [])) | show d == "X" = True
+          isExpectedReason _ = False
+       in expectFailureEof' "<<X" completeLine Hard isExpectedReason 3
 
     context "may end with EOF with no here doc contents pending" $ do
       expectShowEof "foo bar" "" completeLine "foo bar"

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -27,7 +27,6 @@ import Flesh.Language.Parser.HereDoc
 import Flesh.Language.Parser.Lex
 import Flesh.Language.Parser.Syntax
 import Flesh.Language.Parser.TestUtil
-import Flesh.Source.Position
 import Test.Hspec
 
 spec :: Spec
@@ -123,15 +122,12 @@ spec = do
         defaultAliasValue
 
     it "returns nothing after substitution" $
-      let s = defaultAliasName
-          s' = spread (dummyPosition s) s
-          e = runTester at s'
+      let e = runTesterWithDummyPositions at defaultAliasName
        in fmap fst e `shouldBe` Right Nothing
 
     it "stops on recursion" $
-      let s = defaultAliasName
-          s' = spread (dummyPosition s) s
-          e = runTester (reparse aliasableToken >> readAll) s'
+      let e = runTesterWithDummyPositions (reparse aliasableToken >> readAll)
+                defaultAliasName
        in fmap fst e `shouldBe` Right "--color"
 
   describe "redirect" $ return () -- FIXME
@@ -189,9 +185,7 @@ spec = do
       expectFailureEof "" sc Soft UnknownReason 0
 
     it "returns nothing after alias substitution" $
-      let s = defaultAliasName
-          s' = spread (dummyPosition s) s
-          e = runTester sc s'
+      let e = runTesterWithDummyPositions sc defaultAliasName
        in fmap fst e `shouldBe` Right Nothing
 
     context "does not alias-substitute second token" $ do
@@ -207,11 +201,9 @@ spec = do
         defaultAliasValue
 
     it "fills empty here document content" $
-      let s = "<<X\nX\n"
-          s' = spread (dummyPosition s) s
-          f [SimpleCommand [] [] [(_, HereDoc _ c)]] = Just c
+      let f [SimpleCommand [] [] [(_, HereDoc _ c)]] = Just c
           f _ = Nothing
-          e = runTester (f <$> completeLine) s'
+          e = runTesterWithDummyPositions (f <$> completeLine) "<<X\nX\n"
        in fmap fst e `shouldBe` Right (Just (EWord []))
 
     -- TODO it "fills non-empty here document content" pending

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -149,8 +149,11 @@ spec = do
   describe "hereDocContent" $ do
     context "ends with delimiter" $ do
       expectShow "<<-X\nX\n" "" completeLine "0<<-X"
-      expectFailureEof "<<-X\nfoo\n" completeLine
-        Hard UnclosedHereDocContent 5
+
+      let isExpectedReason (UnclosedHereDocContent (HereDocOp 0 True d))
+            | show d == "X" = True
+          isExpectedReason _ = False
+       in expectFailureEof' "<<-X\nfoo\n" completeLine Hard isExpectedReason 5
 
     -- TODO it "accumulates result" pending
 

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -147,7 +147,7 @@ spec = do
     context "ends with delimiter" $ do
       expectShow "<<-X\nX\n" "" completeLine "0<<-X"
 
-      let isExpectedReason (UnclosedHereDocContent (HereDocOp 0 True d))
+      let isExpectedReason (UnclosedHereDocContent (HereDocOp _ 0 True d))
             | show d == "X" = True
           isExpectedReason _ = False
        in expectFailureEof' "<<-X\nfoo\n" completeLine Hard isExpectedReason 5
@@ -210,7 +210,7 @@ spec = do
 
     context "fails with missing here doc contents" $ do
       let isExpectedReason (MissingHereDocContents
-            (HereDocOp 0 False d :| [])) | show d == "X" = True
+            (HereDocOp _ 0 False d :| [])) | show d == "X" = True
           isExpectedReason _ = False
        in expectFailureEof' "<<X" completeLine Hard isExpectedReason 3
 

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -130,7 +130,16 @@ spec = do
                 defaultAliasName
        in fmap fst e `shouldBe` Right "--color"
 
-  describe "redirect" $ return () -- FIXME
+  describe "redirect" $ do
+    let yieldDummyContent = HereDocT $
+          return () <$ (drainOperators >> yieldContent (EWord []))
+        rTester = hereDocOp <$> (fill (redirect <* yieldDummyContent))
+
+    context "parses << operator" $ do
+      expectPositionEof "12<< END"    (hereDocOpPos <$> rTester) 0
+      expectSuccessEof  "12<< END" "" (hereDocFd    <$> rTester) 12
+      expectSuccessEof  "12<< END" "" (isTabbed     <$> rTester) False
+      expectShowEof     "12<< END" "" (delimiter    <$> rTester) "END"
 
   describe "hereDocDelimiter" $ do
     context "is a token followed by a newline" $ do

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -169,9 +169,12 @@ spec = do
     -- are left pending.
 
   describe "newlineHD" $ do
-    it "parses newline" pending -- FIXME
+    context "parses newline" $ do
+      expectSuccess "\n" "" (snd <$> fill newlineHD) '\n'
+      expectPosition "\n" (fst <$> fill newlineHD) 0
 
-    it "parses pending here doc contents after newline" pending -- FIXME
+    context "parses pending here doc contents after newline" $ return ()
+    -- This property is tested in test cases for other properties.
 
   describe "simpleCommand" $ do
     let sc = runAliasT $ fill simpleCommand

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -135,6 +135,30 @@ spec = do
 
   describe "redirect" $ return () -- FIXME
 
+  describe "hereDocDelimiter" $ do
+    it "is a token followed by a newline" pending -- FIXME
+
+    it "matches an unquoted token" pending -- FIXME
+
+    it "can be indented for <<-" pending -- FIXME
+
+  describe "hereDocContent" $ do
+    it "ends with delimiter" pending -- FIXME
+
+    it "accumulates result" pending -- FIXME
+
+  describe "pendingHereDocContents" $ do
+    it "parses 1 pending content" pending -- FIXME
+
+    it "parses 2 pending contents" pending -- FIXME
+
+    it "leaves no pending contents" pending -- FIXME
+
+  describe "newlineHD" $ do
+    it "parses newline" pending -- FIXME
+
+    it "parses pending here doc contents after newline" pending -- FIXME
+
   describe "simpleCommand" $ do
     let sc = runAliasT $ fill simpleCommand
 
@@ -155,5 +179,10 @@ spec = do
     context "does not alias-substitute second token" $ do
       expectShowEof ("foo " ++ defaultAliasName) "" sc $
         "Just foo " ++ defaultAliasName
+
+  describe "completeLine" $ do
+    it "reparses alias" pending -- FIXME
+
+    it "fills here document content" pending -- FIXME
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/hspec-src/Flesh/Language/Parser/TestUtil.hs
+++ b/hspec-src/Flesh/Language/Parser/TestUtil.hs
@@ -61,6 +61,11 @@ runTester :: Tester a -> PositionedString
           -> Either Failure (a, PositionedString)
 runTester parser = runTesterAlias parser defaultAliasDefinitions
 
+runTesterWithDummyPositions :: Tester a -> String
+                            -> Either Failure (a, PositionedString)
+runTesterWithDummyPositions parser s = runTester parser s'
+  where s' = spread (dummyPosition s) s
+
 readAll :: MonadParser m => m String
 readAll = fmap (fmap snd) (many anyChar)
 

--- a/hspec-src/Flesh/Language/Parser/TestUtil.hs
+++ b/hspec-src/Flesh/Language/Parser/TestUtil.hs
@@ -143,4 +143,22 @@ expectFailureEof input parser s r expectedPositionIndex =
      it "fails" $
        e `shouldBe` Left (s, Error r expectedPosition)
 
+-- | @expectFailureEof'@ is like 'expectFailureEof', but tests the reason by
+-- predicate rather than direct comparison. This is useful when the reason
+-- cannot be easily constructed.
+expectFailureEof' :: Show a =>
+  String -> Tester a -> Severity -> (Reason -> Bool) -> Int -> SpecWith ()
+expectFailureEof' input parser s r expectedPositionIndex =
+  let s' = spread (dummyPosition input) input
+      e = runTester parser s'
+      expectedPosition = headPosition (dropP expectedPositionIndex s')
+   in context input $
+       case e of
+         Right e' ->
+           it "fails" $ expectationFailure $ show e'
+         Left (as, Error ar apos) -> do
+           it "fails with expected severity" $ as `shouldBe` s
+           it "fails with expected reason" $ ar `shouldSatisfy` r
+           it "fails at expected position" $ apos `shouldBe` expectedPosition
+
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Parser/Alias.hs
+++ b/src/Flesh/Language/Parser/Alias.hs
@@ -164,13 +164,12 @@ substituteAlias t = do
       cs = unposition $ spread pos $ v
   pushChars cs
 
--- | Modifies a parser so that it retries parsing while it is failing, that
--- is, returning 'Nothing'. This function is mainly meant for retrying after
+-- | Modifies a parser so that it retries parsing while it is failing due to
 -- alias substitution.
-reparse :: Monad m => m (Maybe a) -> m a
+reparse :: Monad m => AliasT m a -> m a
 reparse a = reparse_a
   where reparse_a = do
-          m <- a
+          m <- runAliasT a
           case m of
             Nothing -> reparse_a
             Just v -> return v

--- a/src/Flesh/Language/Parser/Char.hs
+++ b/src/Flesh/Language/Parser/Char.hs
@@ -44,7 +44,7 @@ anyChar = do
 --
 -- Returns 'UnknownReason' on dissatisfaction.
 satisfy :: MonadParser m => (Char -> Bool) -> m (Positioned Char)
-satisfy p = anyChar `satisfying` (p . snd)
+satisfy = satisfying anyChar
 
 -- | Parses the given single character.
 --

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -54,6 +54,7 @@ data Reason =
   | UnclosedDoubleQuote
   | UnclosedSingleQuote
   | MissingRedirectionTarget
+  | UnclosedHereDocContent -- TODO HereDocOp
   deriving (Eq, Show)
 
 -- | Parse error description.

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -148,11 +148,11 @@ failure = currentPosition >>= failureOfPosition
 
 -- | @satisfying m p@ behaves like @m@ but fails if the result of @m@ does not
 -- satisfy predicate @p@. This is analogous to @'flip' 'mfilter'@.
-satisfying :: MonadParser m => m a -> (a -> Bool) -> m a
+satisfying :: MonadParser m
+           => m (P.Positioned a) -> (a -> Bool) -> m (P.Positioned a)
 satisfying m p = do
-  pos <- currentPosition
-  r <- m
-  if p r then return r else failureOfPosition pos
+  posr@(pos, r) <- m
+  if p r then return posr else failureOfPosition pos
 
 -- | @notFollowedBy m@ succeeds if @m@ fails. If @m@ succeeds, it is
 -- equivalent to 'failure'.

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -36,7 +36,7 @@ module Flesh.Language.Parser.Error (
   MonadError(..), failureOfError, failureOfPosition, manyTill, someTill,
   recover, setReason, try, require,
   -- * The 'MonadParser' class
-  MonadParser, failure, satisfying, notFollowedBy, some',
+  MonadParser, failure, failureOfReason, satisfying, notFollowedBy, some',
   -- * The 'ParserT' monad transformer
   ParserT(..), runParserT, mapParserT) where
 
@@ -56,6 +56,7 @@ data Reason =
   | UnclosedSingleQuote
   | MissingRedirectionTarget
   | UnclosedHereDocContent HereDocOp
+  | MissingHereDocContents (NE.NonEmpty HereDocOp)
   deriving (Eq, Show)
 
 -- | Parse error description.
@@ -148,6 +149,12 @@ class (MonadPlus m, MonadInput m, MonadError Failure m) => MonadParser m
 -- | Failure of unknown reason at the current position.
 failure :: MonadParser m => m a
 failure = currentPosition >>= failureOfPosition
+
+-- | Failure of the given reason at the current position.
+failureOfReason :: MonadParser m => Reason -> m a
+failureOfReason r = do
+  p <- currentPosition
+  failureOfError (Error r p)
 
 -- | @satisfying m p@ behaves like @m@ but fails if the result of @m@ does not
 -- satisfy predicate @p@. This is analogous to @'flip' 'mfilter'@.

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -36,7 +36,7 @@ module Flesh.Language.Parser.Error (
   MonadError(..), failureOfError, failureOfPosition, manyTill, someTill,
   recover, setReason, try, require,
   -- * The 'MonadParser' class
-  MonadParser, failure, satisfying, notFollowedBy,
+  MonadParser, failure, satisfying, notFollowedBy, some',
   -- * The 'ParserT' monad transformer
   ParserT(..), runParserT, mapParserT) where
 
@@ -161,6 +161,10 @@ notFollowedBy m = do
   pos <- currentPosition
   let m' = m >> return (failureOfPosition pos)
   join $ catchError m' (const $ return $ return ())
+
+-- | @some' a@ is like @some a@, but returns a NonEmpty list.
+some' :: MonadParser m => m a -> m (NE.NonEmpty a)
+some' a = (NE.:|) <$> a <*> many a
 
 -- | Monad wrapper that instantiates 'MonadParser' from 'MonadInput' and
 -- 'MonadError'.

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -46,6 +46,7 @@ import Control.Monad.Reader
 import Data.Foldable
 import qualified Data.List.NonEmpty as NE
 import Flesh.Language.Parser.Input
+import Flesh.Language.Syntax
 import qualified Flesh.Source.Position as P
 
 -- | Reason of a parse error.
@@ -54,7 +55,7 @@ data Reason =
   | UnclosedDoubleQuote
   | UnclosedSingleQuote
   | MissingRedirectionTarget
-  | UnclosedHereDocContent -- TODO HereDocOp
+  | UnclosedHereDocContent HereDocOp
   deriving (Eq, Show)
 
 -- | Parse error description.

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -53,6 +53,7 @@ data Reason =
   UnknownReason -- ^ Default reason that should be replaced by 'setReason'.
   | UnclosedDoubleQuote
   | UnclosedSingleQuote
+  | MissingRedirectionTarget
   deriving (Eq, Show)
 
 -- | Parse error description.

--- a/src/Flesh/Language/Parser/HereDoc.hs
+++ b/src/Flesh/Language/Parser/HereDoc.hs
@@ -42,7 +42,7 @@ syntax tree.
 -}
 module Flesh.Language.Parser.HereDoc (
   -- * Data types
-  Operator(..), Content,
+  Operator, Content,
   -- * Accumulator
   AccumState, MonadAccum(..), AccumT, runAccumT, mapAccumT,
   -- * Filler
@@ -56,15 +56,7 @@ import Control.Monad.State.Strict
 import Flesh.Language.Syntax
 
 -- | Here document redirection operator type.
-data Operator = Operator {
-  fd :: Int,
-  isTabbed :: Bool,
-  delimiter :: Token}
-  deriving (Eq)
-
-instance Show Operator where
-  showsPrec n o = showsPrec n (fd o) . (s ++) . showsPrec n (delimiter o)
-    where s = if isTabbed o then "<<-" else "<<"
+type Operator = HereDocOp
 
 -- | Here document content type.
 type Content = EWord

--- a/src/Flesh/Language/Parser/HereDoc.hs
+++ b/src/Flesh/Language/Parser/HereDoc.hs
@@ -54,6 +54,7 @@ module Flesh.Language.Parser.HereDoc (
 import Control.Applicative
 import Control.Monad.State.Strict
 import Flesh.Language.Parser.Error
+import Flesh.Language.Parser.Input
 import Flesh.Language.Syntax
 
 -- | Here document redirection operator type.
@@ -146,6 +147,14 @@ instance MonadState s m => MonadState s (AccumT m) where
   get = lift get
   put = lift . put
   state = lift . state
+
+instance MonadParser m => MonadInput (AccumT m) where
+  popChar = lift popChar
+  lookahead = mapAccumT lookahead
+  peekChar = lift peekChar
+  pushChars = lift . pushChars
+
+instance MonadParser m => MonadParser (AccumT m)
 
 -- | State monad that composes final parse results by filling an incomplete
 -- syntax tree with here document contents.

--- a/src/Flesh/Language/Parser/Lex.hs
+++ b/src/Flesh/Language/Parser/Lex.hs
@@ -26,7 +26,7 @@ This module defines utilities for lexical parsing that are specific to the
 shell language.
 -}
 module Flesh.Language.Parser.Lex (
-  lineContinuation, lc, blank, comment, whites, operatorChar, endOfToken)
+  lineContinuation, lc, blank, comment, whites, operatorStarter, endOfToken)
     where
 
 import Control.Applicative
@@ -72,17 +72,18 @@ comment = lc $ do
 whites :: MonadParser m => m (Maybe [Positioned Char])
 whites = many blank *> (Just <$> comment <|> return Nothing)
 
-operatorChars :: [Char]
-operatorChars = ";|&<>()"
+operatorStarters :: [Char]
+operatorStarters = ";|&<>()"
 
--- | Parses a single operator char, possibly preceded by line continuations.
-operatorChar :: MonadParser m => m (Positioned Char)
-operatorChar = lc $ oneOfChars operatorChars
+-- | Parses a single-character operator, possibly preceded by line
+-- continuations.
+operatorStarter :: MonadParser m => m (Positioned Char)
+operatorStarter = lc $ oneOfChars operatorStarters
 
 -- | Succeeds before an end-of-token character. Consumes line continuations
 -- but nothing else.
 endOfToken :: MonadParser m => m ()
 endOfToken = lc $ followedBy op <|> followedBy blank' <|> followedBy eof
-  where op = oneOfChars ('\n' : operatorChars)
+  where op = oneOfChars ('\n' : operatorStarters)
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Parser/Lex.hs
+++ b/src/Flesh/Language/Parser/Lex.hs
@@ -36,6 +36,7 @@ import Flesh.Source.Position
 import Flesh.Language.Parser.Char
 import Flesh.Language.Parser.Error
 import Flesh.Language.Parser.Input
+import Numeric.Natural
 
 -- | Parses a line continuation: a backslash followed by a newline.
 lineContinuation :: MonadParser m => m Position
@@ -129,16 +130,13 @@ redirectOperator = anyOperator `satisfying` isRedirect
         isRedirect _ = False
 
 -- | Parses an IO_NUMBER token.
-ioNumber :: MonadParser m => m Int
+ioNumber :: MonadParser m => m Natural
 ioNumber = do
   ds <- some' digit
   case reads $ snd <$> NE.toList ds of
-    [(n, "")] ->
-      if n > toInteger (maxBound :: Int)
-         then return (-1)
-         else do
-           followedBy $ lc $ oneOfChars "<>"
-           return $ fromInteger n
+    [(n, "")] -> do
+      followedBy $ lc $ oneOfChars "<>"
+      return n
     _ -> failureOfPosition $ fst (NE.head ds)
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Parser/Lex.hs
+++ b/src/Flesh/Language/Parser/Lex.hs
@@ -109,10 +109,6 @@ anyOperator = do
 -- | Parses the given single operator, possibly including line continuations.
 -- The argument operator must be one of the operators parsed by 'anyOperator'.
 operator :: MonadParser m => String -> m (Positioned String)
-operator expected = do
-  actual <- anyOperator
-  if snd actual == expected
-     then return actual
-     else failureOfPosition (fst actual)
+operator o = anyOperator `satisfying` (o ==)
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Parser/Lex.hs
+++ b/src/Flesh/Language/Parser/Lex.hs
@@ -48,14 +48,15 @@ lc m = many lineContinuation *> m
 
 blank' :: MonadParser m => m (Positioned Char)
 blank' = satisfy isBlank
-  where isBlank = (||) <$> isTab <*> isSpace
-        isTab = ('\t' ==)
+  where isBlank c | ord c <= 0x7F = c == '\t' || c == ' '
+                  | otherwise     = isSpace c
 
 -- | Parses a blank character, possibly preceded by line continuations.
 --
 -- In this implementation, the definition of blank characters is
--- locale-independent: it is solely based on the Unicode general category of
--- characters.
+-- locale-independent: For ASCII characters, only the tab and space characters
+-- are blank. For other characters, the categorization is solely based on the
+-- Unicode general category of characters.
 blank :: MonadParser m => m (Positioned Char)
 blank = lc blank'
 

--- a/src/Flesh/Language/Parser/Lex.hs
+++ b/src/Flesh/Language/Parser/Lex.hs
@@ -27,7 +27,7 @@ shell language.
 -}
 module Flesh.Language.Parser.Lex (
   lineContinuation, lc, blank, comment, whites, operatorStarter, endOfToken,
-  anyOperator) where
+  anyOperator, operator) where
 
 import Control.Applicative
 import Data.Char
@@ -105,5 +105,14 @@ anyOperator = do
               return (p, [c1, c2])
            <|> return (p, ">")
     _ -> return (p, [c1])
+
+-- | Parses the given single operator, possibly including line continuations.
+-- The argument operator must be one of the operators parsed by 'anyOperator'.
+operator :: MonadParser m => String -> m (Positioned String)
+operator expected = do
+  actual <- anyOperator
+  if snd actual == expected
+     then return actual
+     else failureOfPosition (fst actual)
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Parser/Lex.hs
+++ b/src/Flesh/Language/Parser/Lex.hs
@@ -27,7 +27,7 @@ shell language.
 -}
 module Flesh.Language.Parser.Lex (
   lineContinuation, lc, blank, digit, comment, whites, operatorStarter,
-  endOfToken, anyOperator, operator, ioNumber) where
+  endOfToken, anyOperator, operator, redirectOperator, ioNumber) where
 
 import Control.Applicative
 import Data.Char
@@ -118,6 +118,14 @@ anyOperator = do
 -- The argument operator must be one of the operators parsed by 'anyOperator'.
 operator :: MonadParser m => String -> m (Positioned String)
 operator o = anyOperator `satisfying` (o ==)
+
+-- | Parses a single direction operator, possibly including line
+-- continuations.
+redirectOperator :: MonadParser m => m (Positioned String)
+redirectOperator = anyOperator `satisfying` isRedirect
+  where isRedirect ('<':_) = True
+        isRedirect ('>':_) = True
+        isRedirect _ = False
 
 -- | Parses an IO_NUMBER token.
 ioNumber :: MonadParser m => m Int

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -179,6 +179,6 @@ simpleCommand = f <$> nonEmptyBody
 
 -- | FIXME
 list :: (MonadParser m, MonadReader Alias.DefinitionSet m) => m Command
-list = reparse $ runAliasT $ fill simpleCommand
+list = reparse $ fill simpleCommand
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -46,6 +46,7 @@ import Flesh.Language.Parser.Alias
 import Flesh.Language.Parser.Char
 import Flesh.Language.Parser.Error
 import Flesh.Language.Parser.HereDoc
+import Flesh.Language.Parser.Input
 import Flesh.Language.Parser.Lex
 import Flesh.Language.Syntax
 import Flesh.Source.Position
@@ -154,16 +155,27 @@ redirect = HereDocT $ do
     "<<-" -> yieldHereDoc $ HereDocOp fd' True t
     _ -> error $ "unexpected redirection operator " ++ op
 
+positionedRedirect :: MonadParser m => HereDocT m (Positioned Redirection)
+positionedRedirect = (,) <$> lift currentPosition <*> redirect
+
 -- | Parses a simple command. Skips whitespaces after the command.
 simpleCommand :: (MonadParser m, MonadReader Alias.DefinitionSet m)
               => HereDocAliasT m Command
-simpleCommand = lift $ f <$> h <*> t
-  where f h' t' = SimpleCommand (h':t') [] []
-        h = aliasableToken
-        t = lift (many normalToken)
+simpleCommand = f <$> nonEmptyBody
+  where f (ts, as, rs) = SimpleCommand ts as rs
+        nonEmptyBody = fRedir <$> redirect' <*> requireHD body <|>
+          fToken <$> aliasableToken' <*> requireHD arguments
+        body = nonEmptyBody <|> pure ([], [], [])
+        arguments = fRedir <$> redirect' <*> requireHD arguments <|>
+          fToken <$> normalToken' <*> requireHD arguments <|>
+          pure ([], [], [])
+        redirect' = mapHereDocT lift positionedRedirect
+        aliasableToken' = lift aliasableToken
+        normalToken' = lift normalToken
+        fRedir r (ts, as, rs) = (ts, as, r:rs)
+        fToken t (ts, as, rs) = (t:ts, as, rs)
 -- TODO global aliases
 -- TODO assignments
--- TODO Redirections
 
 -- | FIXME
 list :: (MonadParser m, MonadReader Alias.DefinitionSet m) => m Command

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -169,7 +169,7 @@ hereDocDelimiter op = do
 hereDocContent :: (MonadParser m, MonadAccum m) => HereDocOp -> m ()
 hereDocContent op = do
   c <- return (EWord []) -- TODO parse content body
-  setReason UnclosedHereDocContent $ hereDocDelimiter op
+  setReason (UnclosedHereDocContent op) $ hereDocDelimiter op
   yieldContent c
 
 pendingHereDocContents :: (MonadParser m, MonadAccum m) => m ()

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -157,9 +157,6 @@ redirect = HereDocT $ do
     "<<-" -> yieldHereDoc $ HereDocOp pos fd' True t
     _ -> error $ "unexpected redirection operator " ++ op
 
-positionedRedirect :: MonadParser m => HereDocT m (Positioned Redirection)
-positionedRedirect = (,) <$> lift currentPosition <*> redirect
-
 hereDocDelimiter :: (MonadParser m, MonadAccum m) => HereDocOp -> m ()
 hereDocDelimiter op = do
   _ <- if isTabbed op then many (char '\t') else return []
@@ -195,7 +192,7 @@ simpleCommand = f <$> nonEmptyBody
         arguments = fRedir <$> redirect' <*> requireHD arguments <|>
           fToken <$> normalToken' <*> requireHD arguments <|>
           pure ([], [], [])
-        redirect' = mapHereDocT lift positionedRedirect
+        redirect' = mapHereDocT lift redirect
         aliasableToken' = lift aliasableToken
         normalToken' = lift normalToken
         fRedir r (ts, as, rs) = (ts, as, r:rs)

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -140,6 +140,7 @@ yieldHereDoc op = do
 -- whitespaces.
 redirect :: MonadParser m => HereDocT m Redirection
 redirect = HereDocT $ do
+  pos <- currentPosition
   (maybeFd, (_opPos, op), t) <- lift redirectBody
   -- TODO define 0 and 1 as constants elsewhere
   let defaultFd = if "<" `isPrefixOf` op then 0 else 1
@@ -152,8 +153,8 @@ redirect = HereDocT $ do
     ">>" -> return $ return $ FileRedirection fd' -- TODO redirection type
     ">|" -> return $ return $ FileRedirection fd' -- TODO redirection type
     ">&" -> return $ return $ FileRedirection fd' -- TODO redirection type
-    "<<" -> yieldHereDoc $ HereDocOp fd' False t
-    "<<-" -> yieldHereDoc $ HereDocOp fd' True t
+    "<<" -> yieldHereDoc $ HereDocOp pos fd' False t
+    "<<-" -> yieldHereDoc $ HereDocOp pos fd' True t
     _ -> error $ "unexpected redirection operator " ++ op
 
 positionedRedirect :: MonadParser m => HereDocT m (Positioned Redirection)

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -169,7 +169,7 @@ hereDocDelimiter op = do
 hereDocContent :: (MonadParser m, MonadAccum m) => HereDocOp -> m ()
 hereDocContent op = do
   c <- return (EWord []) -- TODO parse content body
-  hereDocDelimiter op
+  setReason UnclosedHereDocContent $ hereDocDelimiter op
   yieldContent c
 
 pendingHereDocContents :: (MonadParser m, MonadAccum m) => m ()

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -51,6 +51,7 @@ import Flesh.Language.Parser.Input
 import Flesh.Language.Parser.Lex
 import Flesh.Language.Syntax
 import Flesh.Source.Position
+import Numeric.Natural
 
 -- | Combination of 'HereDocT' and 'AliasT'.
 type HereDocAliasT m a = HereDocT (AliasT m) a
@@ -125,7 +126,7 @@ aliasableToken = AliasT $ do
 -- | Parses a redirection operator (@io_redirect@) and returns the raw result.
 -- Skips trailing whitespaces.
 redirectBody :: MonadParser m
-             => m (Maybe Int, Positioned String, Token)
+             => m (Maybe Natural, Positioned String, Token)
 redirectBody = liftA3 (,,) (optional ioNumber) redirectOperator
   (whites *> require (setReason MissingRedirectionTarget normalToken))
 

--- a/src/Flesh/Language/Syntax.hs
+++ b/src/Flesh/Language/Syntax.hs
@@ -39,6 +39,7 @@ module Flesh.Language.Syntax (
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import qualified Flesh.Source.Position as P
+import Numeric.Natural
 
 -- | Element of double quotes.
 data DoubleQuoteUnit =
@@ -137,7 +138,7 @@ instance Show Assignment where
 -- | Here document redirection operator.
 data HereDocOp = HereDocOp {
   hereDocOpPos :: P.Position,
-  hereDocFd :: Int,
+  hereDocFd :: Natural,
   isTabbed :: Bool,
   delimiter :: Token}
   deriving (Eq)
@@ -150,7 +151,7 @@ instance Show HereDocOp where
 -- | Redirection.
 data Redirection =
   FileRedirection {
-    fileFd :: Int} -- FIXME
+    fileFd :: Natural} -- FIXME
   | HereDoc {
     hereDocOp :: HereDocOp,
     content :: EWord}
@@ -164,7 +165,7 @@ instance Show Redirection where
   showList (r:rs) = showsPrec 0 r . (' ':) . showList rs
 
 -- | Returns the target file descriptor of the given redirection.
-fd :: Redirection -> Int
+fd :: Redirection -> Natural
 fd (FileRedirection fd') = fd'
 fd (HereDoc (HereDocOp _ fd' _ _) _) = fd'
 

--- a/src/Flesh/Language/Syntax.hs
+++ b/src/Flesh/Language/Syntax.hs
@@ -189,5 +189,8 @@ instance Show Command where
     showList as' . (' ':) . showsPrec n (SimpleCommand ts [] rs)
     where as' = snd <$> as
   showsPrec _ FunctionDefinition = id -- FIXME
+  showList [] = id
+  showList [c] = showsPrec 0 c
+  showList (c:cs) = showsPrec 0 c . ("; " ++) . showList cs
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Syntax.hs
+++ b/src/Flesh/Language/Syntax.hs
@@ -171,7 +171,7 @@ fd (HereDoc (HereDocOp _ fd' _ _) _) = fd'
 -- | Element of pipelines.
 data Command =
   -- | Simple command.
-  SimpleCommand [Token] [P.Positioned Assignment] [P.Positioned Redirection]
+  SimpleCommand [Token] [P.Positioned Assignment] [Redirection]
   -- FIXME Compound commands
   -- | Function definition.
   | FunctionDefinition -- FIXME
@@ -182,10 +182,8 @@ instance Show Command where
   showsPrec _ (SimpleCommand ts [] []) = showList ts
   showsPrec _ (SimpleCommand [] as []) = showList as'
     where as' = snd <$> as
-  showsPrec _ (SimpleCommand [] [] rs) = showList rs'
-    where rs' = snd <$> rs
-  showsPrec _ (SimpleCommand ts [] rs) = showList ts . (' ':) . showList rs'
-    where rs' = snd <$> rs
+  showsPrec _ (SimpleCommand [] [] rs) = showList rs
+  showsPrec _ (SimpleCommand ts [] rs) = showList ts . (' ':) . showList rs
   showsPrec n (SimpleCommand ts as rs) =
     showList as' . (' ':) . showsPrec n (SimpleCommand ts [] rs)
     where as' = snd <$> as

--- a/src/Flesh/Language/Syntax.hs
+++ b/src/Flesh/Language/Syntax.hs
@@ -136,6 +136,7 @@ instance Show Assignment where
 
 -- | Here document redirection operator.
 data HereDocOp = HereDocOp {
+  hereDocOpPos :: P.Position,
   hereDocFd :: Int,
   isTabbed :: Bool,
   delimiter :: Token}
@@ -165,7 +166,7 @@ instance Show Redirection where
 -- | Returns the target file descriptor of the given redirection.
 fd :: Redirection -> Int
 fd (FileRedirection fd') = fd'
-fd (HereDoc (HereDocOp fd' _ _) _) = fd'
+fd (HereDoc (HereDocOp _ fd' _ _) _) = fd'
 
 -- | Element of pipelines.
 data Command =

--- a/src/Flesh/Language/Syntax.hs
+++ b/src/Flesh/Language/Syntax.hs
@@ -179,11 +179,15 @@ data Command =
 instance Show Command where
   showsPrec _ (SimpleCommand [] [] []) = id
   showsPrec _ (SimpleCommand ts [] []) = showList ts
-  showsPrec _ (SimpleCommand [] as []) = showList as
-  showsPrec _ (SimpleCommand [] [] rs) = showList rs
-  showsPrec _ (SimpleCommand ts [] rs) = showList ts . (' ':) . showList rs
+  showsPrec _ (SimpleCommand [] as []) = showList as'
+    where as' = snd <$> as
+  showsPrec _ (SimpleCommand [] [] rs) = showList rs'
+    where rs' = snd <$> rs
+  showsPrec _ (SimpleCommand ts [] rs) = showList ts . (' ':) . showList rs'
+    where rs' = snd <$> rs
   showsPrec n (SimpleCommand ts as rs) =
-    showList as . (' ':) . showsPrec n (SimpleCommand ts [] rs)
+    showList as' . (' ':) . showsPrec n (SimpleCommand ts [] rs)
+    where as' = snd <$> as
   showsPrec _ FunctionDefinition = id -- FIXME
 
 -- vim: set et sw=2 sts=2 tw=78:


### PR DESCRIPTION
 - [x] Define here document redirection operator syntax.
 - [x] Define operator parser.
 - [x] Define `IO_NUMBER` parser.
 - Define `io_here` parser.
   - [x] Implement parser.
   - [x] Test parser.
 - [x] Parse here-document contents after a newline.
 - [x] Change the file descriptor type to `Natural`.
 - [x] Save redirection operator position in `Redirection`.