### PR TITLE
Prevent recursive alias substitution

### DIFF
--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -120,8 +120,7 @@ spec = do
       expectShow "f${1}o" ";" at "Just f${1}o"
 
     context "modifies pending input" $ do
-      expectSuccessEof defaultAliasName "" (at >> readAll) $
-        defaultAliasValue
+      expectSuccessEof defaultAliasName "" (at >> readAll) defaultAliasValue
 
     it "returns nothing after substitution" $
       let e = runTesterWithDummyPositions at defaultAliasName

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -132,6 +132,11 @@ spec = do
                 defaultAliasName
        in fmap fst e `shouldBe` Right "--color"
 
+    it "stops on exact recursion" $
+      let e = runTesterWithDummyPositions (reparse aliasableToken >> readAll)
+                recursiveAlias
+       in fmap fst e `shouldBe` Right ""
+
   describe "reserved" $ do
     context "returns matching unquoted token" $ do
       expectShowEof "! " "" (reserved (T.pack "!")) "!"

--- a/hspec-src/Flesh/Language/Parser/TestUtil.hs
+++ b/hspec-src/Flesh/Language/Parser/TestUtil.hs
@@ -44,11 +44,18 @@ defaultAliasName = "ls"
 defaultAliasValue :: String
 defaultAliasValue = defaultAliasName ++ " --color"
 
+recursiveAlias :: String
+recursiveAlias = "rec"
+
 defaultAliasDefinitions :: Alias.DefinitionSet
-defaultAliasDefinitions = M.singleton n $ Alias.definition n v p
-  where n = T.pack defaultAliasName
-        v = T.pack defaultAliasValue
-        p = dummyPosition "alias ls='ls --color'"
+defaultAliasDefinitions =
+  M.insert n (Alias.definition n v p) $
+    M.singleton r (Alias.definition r r pr)
+      where n = T.pack defaultAliasName
+            v = T.pack defaultAliasValue
+            p = dummyPosition "alias ls='ls --color'"
+            r = T.pack recursiveAlias
+            pr = dummyPosition "alias rec=rec"
 
 runTesterAlias :: Tester a -> Alias.DefinitionSet -> PositionedString
                -> Either Failure (a, PositionedString)

--- a/src/Flesh/Language/Parser/Alias.hs
+++ b/src/Flesh/Language/Parser/Alias.hs
@@ -148,14 +148,10 @@ applicable _ _ = True
 -- Returns @'return' ()@ if substitution was performed; returns 'Nothing'
 -- otherwise.
 substituteAlias :: (MonadReader DefinitionSet m, MonadInput m)
-                => T.Text -> MaybeT m ()
-substituteAlias t = do
+                => Position -> T.Text -> MaybeT m ()
+substituteAlias pos' t = do
   defs <- ask
   def <- MaybeT $ return $ M.lookup t defs
-  pos' <- currentPosition
-  -- FIXME @applicable t pos'@ is not the correct test for recursive
-  -- substitution. The position of the substituted text should be tested but
-  -- @pos'@ is /after/ the text.
   guard $ applicable t pos'
   let a = Alias pos' def
       v = T.unpack $ value def

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -43,6 +43,7 @@ import Control.Monad.Trans.Maybe
 import Data.Foldable
 import Data.List
 import Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.List.NonEmpty as NE
 import Data.Maybe
 import qualified Data.Text as T
 import qualified Flesh.Language.Alias as Alias
@@ -122,7 +123,8 @@ aliasableToken = AliasT $ do
   let inv Nothing = Just t
       inv (Just ()) = Nothing
       tt = MaybeT $ return $ tokenText t
-   in fmap inv $ runMaybeT $ tt >>= substituteAlias
+      pos = fst $ NE.head $ tokenUnits t
+   in fmap inv $ runMaybeT $ tt >>= substituteAlias pos
    -- TODO substitute the next token if the current substitute ends with a
    -- blank.
 


### PR DESCRIPTION
The substituteAlias function needs to take as an argument the position
of the token being alias-substituted. The previous implementation was
wrong in that the function was using the position _after_ the token,
which cannot be used to detect recursive alias substitution.