### PR TITLE
Pretty printing as a temporary "main" implementation

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,4 +1,6 @@
 module Main where
 
+import qualified Flesh.Language.Pretty as P
+
 main :: IO ()
-main = mempty
+main = P.main

--- a/flesh.cabal
+++ b/flesh.cabal
@@ -25,6 +25,7 @@ library
                        Flesh.Language.Parser.Lex,
                        Flesh.Language.Parser.Syntax,
                        Flesh.Language.Parser.Warning,
+                       Flesh.Language.Pretty,
                        Flesh.Language.Syntax,
                        Flesh.Language.Syntax.Print,
                        Flesh.Source.Position

--- a/flesh.cabal
+++ b/flesh.cabal
@@ -26,6 +26,7 @@ library
                        Flesh.Language.Parser.Syntax,
                        Flesh.Language.Parser.Warning,
                        Flesh.Language.Syntax,
+                       Flesh.Language.Syntax.Print,
                        Flesh.Source.Position
   build-depends:       base >= 4.9 && < 5,
                        containers >= 0.5.0.0 && < 1,

--- a/src/Flesh/Language/Pretty.hs
+++ b/src/Flesh/Language/Pretty.hs
@@ -1,0 +1,139 @@
+{-
+Copyright (C) 2017 WATANABE Yuki <magicant@wonderwand.net>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-}
+
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE Safe #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-|
+Copyright   : (C) 2017 WATANABE Yuki
+License     : GPL-2
+Portability : portable
+
+This module implements pretty printing feature.
+-}
+module Flesh.Language.Pretty (main) where
+
+import Control.Monad.Except
+import Control.Monad.Reader
+import Control.Monad.State.Strict
+import Data.Map.Lazy
+import Flesh.Language.Parser.Error
+import Flesh.Language.Parser.Input
+import Flesh.Language.Parser.Syntax
+import Flesh.Language.Syntax.Print
+import Flesh.Source.Position
+import System.Exit
+import System.IO.Error
+
+data InputRecord = InputRecord {
+  readChars :: [Positioned Char],
+  eofError :: Maybe IOError}
+
+type StandardInputT = StateT InputRecord
+
+runStandardInputT :: Functor m => StandardInputT m a -> m a
+runStandardInputT = fmap fst . flip runStateT r
+  where r = InputRecord {readChars = [], eofError = Nothing}
+
+stdinFragment :: String -> Int -> Fragment
+stdinFragment = flip Fragment StandardInput
+
+nextPosition :: String -> [Positioned Char] -> Position
+nextPosition s [] = Position {fragment = stdinFragment s 0, index = 0}
+nextPosition s [pc] = Position {fragment = stdinFragment s n, index = 0}
+  where n = lineNo (fragment (fst pc)) + 1
+nextPosition s (_:pcs) = nextPosition s pcs
+
+readNextLine :: (MonadState InputRecord m, MonadIO m) => m ()
+readNextLine = do
+  errorOrLine <- liftIO (tryIOError getLine)
+  InputRecord {readChars = rcs, eofError = ee} <- get
+  case errorOrLine of
+    Left e -> put InputRecord {readChars = rcs, eofError = Just e}
+    Right l -> put InputRecord {readChars = rcs ++ lcs, eofError = ee}
+      where lcs = unposition (spread p l')
+            p = nextPosition l' rcs
+            l' = l ++ "\n"
+
+inputChar :: (MonadState InputRecord m, MonadIO m)
+     => Int -> m (Either Position (Positioned Char))
+inputChar i = ci
+  where ci = do
+          InputRecord {readChars = rcs, eofError = ee} <- get
+          case drop i rcs of
+            (pc:_) -> return (Right pc)
+            [] ->
+              case ee of
+                Just _ -> return (Left (nextPosition "" rcs))
+                Nothing -> readNextLine >> ci
+
+type InputPosition = Int
+newtype CursorT m a = CursorT (StateT InputPosition m a)
+
+runCursorT :: CursorT m a -> StateT InputPosition m a
+runCursorT (CursorT m) = m
+
+runCursorT' :: Functor m => CursorT m a -> m a
+runCursorT' = fmap fst . flip runStateT 0 . runCursorT
+
+instance Functor m => Functor (CursorT m) where
+  fmap f = CursorT . fmap f . runCursorT
+
+instance Monad m => Applicative (CursorT m) where
+  pure = CursorT . pure
+  CursorT a <*> CursorT b = CursorT (a <*> b)
+
+instance Monad m => Monad (CursorT m) where
+  CursorT a >>= f = CursorT (a >>= runCursorT . f)
+
+instance MonadError e m => MonadError e (CursorT m) where
+  throwError = CursorT . throwError
+  catchError (CursorT a) f =
+    CursorT (catchError a (runCursorT . f))
+
+instance (MonadState InputRecord m, MonadIO m) => MonadInput (CursorT m) where
+  popChar = CursorT $ do
+    i <- get
+    put (i + 1)
+    lift (inputChar i)
+  peekChar = CursorT $ do
+    i <- get
+    lift (inputChar i)
+  lookahead (CursorT m) = CursorT $ do
+    oldPos <- get
+    v <- m
+    put oldPos
+    return v
+  pushChars = undefined -- FIXME
+
+readCompleteLine :: IO (Either Failure [AndOrList])
+readCompleteLine = runStandardInputT $ runExceptT $ runCursorT' $
+  flip runReaderT empty $ runParserT completeLine
+
+writeCompleteLine :: Either Failure [AndOrList] -> IO ()
+writeCompleteLine (Left _e) = exitFailure -- TODO write error
+writeCompleteLine (Right aols) = putStr (runPrint (printList aols) "")
+
+-- | Repeatedly reads commands from the standard input and pretty-prints them
+-- to the standard output.
+main :: IO ()
+main = readCompleteLine >>= writeCompleteLine >> main
+
+-- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Pretty.hs
+++ b/src/Flesh/Language/Pretty.hs
@@ -34,6 +34,7 @@ import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State.Strict
 import Data.Map.Lazy
+import Flesh.Language.Parser.Char
 import Flesh.Language.Parser.Error
 import Flesh.Language.Parser.Input
 import Flesh.Language.Parser.Syntax
@@ -125,7 +126,7 @@ instance (MonadState InputRecord m, MonadIO m) => MonadInput (CursorT m) where
 
 readCompleteLine :: IO (Either Failure [AndOrList])
 readCompleteLine = runStandardInputT $ runExceptT $ runCursorT' $
-  flip runReaderT empty $ runParserT completeLine
+  flip runReaderT empty $ runParserT $ notFollowedBy eof *> completeLine
 
 writeCompleteLine :: Either Failure [AndOrList] -> IO ()
 writeCompleteLine (Left _e) = exitFailure -- TODO write error

--- a/src/Flesh/Language/Syntax/Print.hs
+++ b/src/Flesh/Language/Syntax/Print.hs
@@ -1,0 +1,177 @@
+{-
+Copyright (C) 2017 WATANABE Yuki <magicant@wonderwand.net>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-}
+
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE Safe #-}
+
+{-|
+Copyright   : (C) 2017 WATANABE Yuki
+License     : GPL-2
+Portability : non-portable (flexible contexts)
+
+This module defines functions for printing parsed syntax. The functions in
+this module print in multi-line format including here document contents,
+unlike the Show instances implemented in Flesh.Language.Syntax, which print in
+single-line format without here document contents.
+-}
+module Flesh.Language.Syntax.Print (
+  PrintState(..), initPrintState,
+  PrintS, runPrint,
+  Printable(..), ListPrintable(..)) where
+
+import Control.Monad.State.Strict
+import Control.Monad.Writer.Lazy
+import Data.List.NonEmpty (NonEmpty(..))
+import Flesh.Language.Syntax
+
+-- | Intermediate state used while constructing a printer function.
+data PrintState = PrintState {
+  -- | Number of spaces at the beginning of lines.
+  indent :: !Int,
+  -- | Function to print here document contents at the next newline.
+  hereDoc :: ShowS}
+
+-- | Initial state to initiate the PrintS monad.
+initPrintState :: PrintState
+initPrintState = PrintState 0 id
+
+-- | Monad to construct ShowS functions.
+--
+-- The outer State monad carries PrintState, from which the ShowS function
+-- results in the inner WriterT monad.
+type PrintS = WriterT (Endo String) (State PrintState)
+
+-- | Runs the PrintS state with 'initPrintState'.
+runPrint :: PrintS a -> ShowS
+runPrint = appEndo . flip evalState initPrintState . execWriterT
+
+-- | Utility for yielding a ShowS function
+tell' :: MonadWriter (Endo String) m => ShowS -> m ()
+tell' = tell . Endo
+
+-- | Utility for Show instances
+showSpace' :: MonadWriter (Endo String) m => m ()
+showSpace' = tell' $ showChar ' '
+
+-- | Appends the given here document content to the current 'hereDoc'.
+appendHereDoc :: MonadState PrintState m => ShowS -> m ()
+appendHereDoc s = modify' (\(PrintState i h) -> PrintState i (h . s))
+
+-- | Shows the current 'hereDoc' and clears it.
+printHereDoc :: (MonadState PrintState m, MonadWriter (Endo String) m) => m ()
+printHereDoc = state (\(PrintState i h) -> (Endo h, PrintState i id)) >>= tell
+
+-- | Shows as many spaces as 'indent' of the current state.
+printIndent :: (MonadState PrintState m, MonadWriter (Endo String) m) => m ()
+printIndent = do
+  s <- get
+  tell' $ showString $ replicate (indent s) ' '
+
+-- | Combination of @showChar '\n'@ and 'printHereDoc' and 'printIndent'.
+printNewline :: (MonadState PrintState m, MonadWriter (Endo String) m) => m ()
+printNewline = do
+  tell' $ showChar '\n'
+  printHereDoc
+  printIndent
+
+-- | Class of printable syntax.
+class Printable s where
+  -- | Prints the given syntax.
+  prints :: (MonadState PrintState m, MonadWriter (Endo String) m) => s -> m ()
+
+-- | Class of printable lists of syntax.
+class ListPrintable s where
+  -- | Prints the given list of syntax.
+  printList :: (MonadState PrintState m, MonadWriter (Endo String) m)
+            => [s] -> m ()
+
+instance Printable Redirection where
+  prints r@(FileRedirection _) = tell' $ shows r
+  prints r@(HereDoc op cntnt) = do
+    appendHereDoc $ showContent . showDelimiter . showChar '\n'
+    tell' $ shows r
+      where showContent = showList $ snd $ unzip cntnt
+            showDelimiter = showList $ snd $ unquoteToken $ delimiter op
+
+instance ListPrintable Redirection where
+  printList [] = return ()
+  printList [r] = prints r
+  printList (r:rs) = foldl printSpaceAnd (prints r) rs
+    where printSpaceAnd mrs' r' = do 
+            () <- mrs'
+            showSpace'
+            prints r'
+
+instance Printable Command where
+  prints (SimpleCommand [] [] []) = return ()
+  prints c@(SimpleCommand _ _ []) = tell' $ shows c
+  prints (SimpleCommand [] [] rs) = printList rs
+  prints (SimpleCommand ts as rs) = do
+    prints (SimpleCommand ts as [])
+    showSpace'
+    printList rs
+  prints FunctionDefinition = undefined -- TODO
+
+instance Printable Pipeline where
+  prints p = do
+    when (isNegated p) (tell' $ showString "! ")
+    foldl printPipeAnd (prints c) cs
+      where c :| cs = pipeCommands p
+            printPipeAnd mcs' c' = do
+              () <- mcs'
+              tell' $ showString " |"
+              printNewline
+              prints c'
+
+instance Printable ConditionalPipeline where
+  prints (ConditionalPipeline (c, p)) = do
+    tell' $ shows c
+    printNewline
+    prints p
+
+instance ListPrintable ConditionalPipeline where
+  printList [] = return ()
+  printList [p] = prints p
+  printList (p:ps) = do
+    prints p
+    showSpace'
+    printList ps
+
+printAndOrHeadTail :: (MonadState PrintState m, MonadWriter (Endo String) m)
+                   => Pipeline -> [ConditionalPipeline] -> m ()
+printAndOrHeadTail h [] = prints h
+printAndOrHeadTail h t = do
+  prints h
+  showSpace'
+  printList t
+
+instance Printable AndOrList where
+  prints (AndOrList p ps asy) = do
+    printAndOrHeadTail p ps
+    when asy $ tell' $ showChar '&'
+    tell' $ showChar '\n'
+    printHereDoc
+
+instance ListPrintable AndOrList where
+  printList [] = return ()
+  printList [a] = prints a
+  printList (a:as) = do
+    prints a
+    printIndent
+    printList as
+
+-- vim: set et sw=2 sts=2 tw=78:


### PR DESCRIPTION
Currently, the "main" function is nop and "flesh" is useless. This PR implements it as a simple pretty-printer of the shell language.

TODO:

- ~~Error message~~
- ~~Bug: A redundant input line is being required after each input of `completeLine`.~~
- [x] `InputPositionT` could be better named `CursorT`.
- ~~Implement `pushChars`. (Seems the `InputPosition` type needs to be redefined.)~~
- [x] `StandardInputT` could be declared `type` rather than `newtype`.
- [x] Define `PrintS` as a composition of `State PrintState` and `Writer (Endo String)`.
- [x] Bug: Quoted here-document delimiter should be printed unquoted.
- [x] Bug: Stop on EOF.
