### PR TITLE
Testing for unnecessary input requesting

### DIFF
--- a/flesh.cabal
+++ b/flesh.cabal
@@ -19,6 +19,7 @@ library
                        Flesh.Language.Alias.Core,
                        Flesh.Language.Parser.Alias,
                        Flesh.Language.Parser.Char,
+                       Flesh.Language.Parser.Class,
                        Flesh.Language.Parser.Error,
                        Flesh.Language.Parser.HereDoc,
                        Flesh.Language.Parser.Input,

--- a/hspec-src/Flesh/Language/Parser/AliasSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/AliasSpec.hs
@@ -24,7 +24,7 @@ import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import Flesh.Language.Alias
 import Flesh.Language.Parser.Alias
-import Flesh.Language.Parser.Error
+import Flesh.Language.Parser.Class
 import Flesh.Language.Parser.TestUtil
 import Flesh.Source.Position
 import Test.Hspec

--- a/hspec-src/Flesh/Language/Parser/ErrorSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/ErrorSpec.hs
@@ -25,6 +25,7 @@ import Control.Applicative
 import Control.Monad.Except
 import Control.Monad.Identity
 import Control.Monad.State.Strict
+import Flesh.Language.Parser.Class
 import Flesh.Language.Parser.Error
 import Flesh.Source.Position
 import Test.Hspec

--- a/hspec-src/Flesh/Language/Parser/TestUtil.hs
+++ b/hspec-src/Flesh/Language/Parser/TestUtil.hs
@@ -28,8 +28,8 @@ import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import qualified Flesh.Language.Alias as Alias
 import Flesh.Language.Parser.Char
+import Flesh.Language.Parser.Class
 import Flesh.Language.Parser.Error
---import Flesh.Language.Parser.Input
 import Flesh.Source.Position
 import Test.Hspec
 import Test.Hspec.QuickCheck

--- a/src/Flesh/Language/Parser/Alias.hs
+++ b/src/Flesh/Language/Parser/Alias.hs
@@ -42,6 +42,7 @@ import Control.Monad.Trans.Maybe
 import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import Flesh.Language.Alias
+import Flesh.Language.Parser.Class
 import Flesh.Language.Parser.Error
 import Flesh.Language.Parser.Input
 import Flesh.Source.Position

--- a/src/Flesh/Language/Parser/Char.hs
+++ b/src/Flesh/Language/Parser/Char.hs
@@ -26,6 +26,7 @@ This module defines character parsers.
 -}
 module Flesh.Language.Parser.Char where
 
+import Flesh.Language.Parser.Class
 import Flesh.Language.Parser.Error
 import Flesh.Language.Parser.Input
 import Flesh.Source.Position

--- a/src/Flesh/Language/Parser/Class.hs
+++ b/src/Flesh/Language/Parser/Class.hs
@@ -1,0 +1,180 @@
+{-
+Copyright (C) 2017 WATANABE Yuki <magicant@wonderwand.net>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-}
+
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE Safe #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-|
+Copyright   : (C) 2017 WATANABE Yuki
+License     : GPL-2
+Portability : non-portable (GHC language extensions)
+
+This module defines types that describe parse errors for the shell language
+and a monad transformer that injects parse error handling into another monad.
+-}
+module Flesh.Language.Parser.Class (
+  -- * The 'MonadParser' class
+  MonadParser, failure, failureOfReason, satisfying, satisfyingP,
+  notFollowedBy, some',
+  -- * The 'ParserT' monad transformer
+  ParserT(..), runParserT, mapParserT) where
+
+import Control.Applicative
+import Control.Monad.Except
+import Control.Monad.Reader
+import Data.Foldable
+import Data.List.NonEmpty (NonEmpty(..))
+import Flesh.Language.Parser.Error
+import Flesh.Language.Parser.Input
+import qualified Flesh.Source.Position as P
+
+-- | Collection of properties required for basic parser implementation.
+--
+-- @MonadParser@ is a subclass of the input and error handling monads,
+-- supporting the basic behavior of the parser. It is also an instance of
+-- 'Alternative' and 'MonadPlus', where
+--
+--  * 'empty' and 'mzero' are equal to 'failure'; and
+--  * '<|>' and 'mplus' behave like 'catchError' but they only catch 'Soft'
+--    failures.
+class (MonadPlus m, MonadInput m, MonadError Failure m) => MonadParser m
+
+-- | Failure of unknown reason at the current position.
+failure :: MonadParser m => m a
+failure = currentPosition >>= failureOfPosition
+
+-- | Failure of the given reason at the current position.
+failureOfReason :: MonadParser m => Reason -> m a
+failureOfReason r = do
+  p <- currentPosition
+  failureOfError (Error r p)
+
+-- | @satisfying m p@ behaves like @m@ but fails if the result of @m@ does not
+-- satisfy predicate @p@. This is analogous to @'flip' 'mfilter'@.
+satisfying :: MonadParser m => m a -> (a -> Bool) -> m a
+satisfying m p = do
+  pos <- currentPosition
+  r <- m
+  if p r then return r else failureOfPosition pos
+
+-- | 'satisfyingP' is like 'satisfying' but applies the predicate to the
+-- second item of the pair.
+satisfyingP :: MonadParser m
+            => m (P.Positioned a) -> (a -> Bool) -> m (P.Positioned a)
+-- satisfyingP m p = satisfying m (p . snd)
+-- This would return a better error position:
+satisfyingP m p = do
+  posr@(pos, r) <- m
+  if p r then return posr else failureOfPosition pos
+
+-- | @notFollowedBy m@ succeeds if @m@ fails. If @m@ succeeds, it is
+-- equivalent to 'failure'.
+notFollowedBy :: MonadParser m => m a -> m ()
+notFollowedBy m = do
+  pos <- currentPosition
+  let m' = m >> return (failureOfPosition pos)
+  join $ catchError m' (const $ return $ return ())
+
+-- | @some' a@ is like @some a@, but returns a NonEmpty list.
+some' :: MonadParser m => m a -> m (NonEmpty a)
+some' a = (:|) <$> a <*> many a
+
+-- | Monad wrapper that instantiates 'MonadParser' from 'MonadInput' and
+-- 'MonadError'.
+--
+-- As an instance of 'Functor', 'Foldable', 'Applicative' and 'Monad',
+-- @ParserT m@ behaves the same as the original monad @m@. The 'Alternative'
+-- instance for @ParserT@ is constructed from the 'MonadError' instance to
+-- obey the 'MonadParser' laws.
+newtype ParserT m a = ParserT (m a)
+  deriving (Eq, Show)
+
+-- | Returns the value of 'ParserT'.
+runParserT :: ParserT m a -> m a
+runParserT (ParserT m) = m
+
+-- | Directly modifies the value of 'ParserT'.
+mapParserT :: (m a -> n b) -> ParserT m a -> ParserT n b
+mapParserT f = ParserT . f . runParserT
+
+instance Functor m => Functor (ParserT m) where
+  fmap f = ParserT . fmap f . runParserT
+  a <$ ParserT b = ParserT (a <$ b)
+
+instance Foldable m => Foldable (ParserT m) where
+  fold = fold . runParserT
+  foldMap f = foldMap f . runParserT
+  foldr f z = foldr f z . runParserT
+  foldr' f z = foldr' f z . runParserT
+  foldl f z = foldl f z . runParserT
+  foldl' f z = foldl' f z . runParserT
+  foldr1 f = foldr1 f . runParserT
+  foldl1 f = foldl1 f . runParserT
+  toList = toList . runParserT
+  null = null . runParserT
+  length = length . runParserT
+  elem e = elem e . runParserT
+  maximum = maximum . runParserT
+  minimum = minimum . runParserT
+  sum = sum . runParserT
+  product = product . runParserT
+
+instance Applicative m => Applicative (ParserT m) where
+  pure = ParserT . pure
+  ParserT a <*> ParserT b = ParserT (a <*> b)
+  ParserT a  *> ParserT b = ParserT (a  *> b)
+  ParserT a <*  ParserT b = ParserT (a <*  b)
+
+instance Monad m => Monad (ParserT m) where
+  return = ParserT . return
+  ParserT a >>= f = ParserT (a >>= runParserT . f)
+  ParserT a >> ParserT b = ParserT (a >> b)
+
+instance MonadTrans ParserT where
+  lift = ParserT
+
+instance MonadInput m => MonadInput (ParserT m) where
+  popChar = lift popChar
+  lookahead = mapParserT lookahead
+  peekChar = lift peekChar
+  pushChars = lift <$> pushChars
+
+instance MonadError e m => MonadError e (ParserT m) where
+  throwError = ParserT . throwError
+  catchError (ParserT m) f = ParserT (catchError m (runParserT . f))
+
+instance (MonadInput m, MonadError Failure m)
+    => Alternative (ParserT m) where
+  empty = failure
+  a <|> b =
+    a `catchError` handle
+      where handle (Soft, _) = b
+            handle e = throwError e
+
+instance (MonadInput m, MonadError Failure m) => MonadPlus (ParserT m)
+
+instance (MonadInput m, MonadError Failure m) => MonadParser (ParserT m)
+
+instance MonadReader r m => MonadReader r (ParserT m) where
+  ask = lift ask
+  local f = mapParserT $ local f
+  reader = lift . reader
+
+-- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -41,6 +41,7 @@ import qualified Flesh.Source.Position as P
 -- | Reason of a parse error.
 data Reason =
   UnknownReason -- ^ Default reason that should be replaced by 'setReason'.
+  | InputError IOError
   | UnclosedDoubleQuote
   | UnclosedSingleQuote
   | MissingRedirectionTarget

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -16,37 +16,25 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -}
 
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE Safe #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 {-|
 Copyright   : (C) 2017 WATANABE Yuki
 License     : GPL-2
-Portability : non-portable (GHC language extensions)
+Portability : non-portable (flexible contexts)
 
 This module defines types that describe parse errors for the shell language
-and a monad transformer that injects parse error handling into another monad.
+and utilities for handling errors in monads.
 -}
 module Flesh.Language.Parser.Error (
   -- * Basic types
   Reason(..), Error(..), Severity(..), Failure,
   -- * Utilities for 'MonadError'
   MonadError(..), failureOfError, failureOfPosition, manyTill, someTill,
-  manyTo, recover, setReason, try, require,
-  -- * The 'MonadParser' class
-  MonadParser, failure, failureOfReason, satisfying, satisfyingP,
-  notFollowedBy, some',
-  -- * The 'ParserT' monad transformer
-  ParserT(..), runParserT, mapParserT) where
+  manyTo, recover, setReason, try, require) where
 
-import Control.Applicative
 import Control.Monad.Except
-import Control.Monad.Reader
-import Data.Foldable
 import Data.List.NonEmpty (NonEmpty(..))
-import Flesh.Language.Parser.Input
 import Flesh.Language.Syntax
 import qualified Flesh.Source.Position as P
 
@@ -145,137 +133,5 @@ try m = catchError m (throwError . handle)
 require :: MonadError Failure m => m a -> m a
 require m = catchError m (throwError . handle)
   where handle (_, e) = (Hard, e)
-
--- | Collection of properties required for basic parser implementation.
---
--- @MonadParser@ is a subclass of the input and error handling monads,
--- supporting the basic behavior of the parser. It is also an instance of
--- 'Alternative' and 'MonadPlus', where
---
---  * 'empty' and 'mzero' are equal to 'failure'; and
---  * '<|>' and 'mplus' behave like 'catchError' but they only catch 'Soft'
---    failures.
-class (MonadPlus m, MonadInput m, MonadError Failure m) => MonadParser m
-
--- | Failure of unknown reason at the current position.
-failure :: MonadParser m => m a
-failure = currentPosition >>= failureOfPosition
-
--- | Failure of the given reason at the current position.
-failureOfReason :: MonadParser m => Reason -> m a
-failureOfReason r = do
-  p <- currentPosition
-  failureOfError (Error r p)
-
--- | @satisfying m p@ behaves like @m@ but fails if the result of @m@ does not
--- satisfy predicate @p@. This is analogous to @'flip' 'mfilter'@.
-satisfying :: MonadParser m => m a -> (a -> Bool) -> m a
-satisfying m p = do
-  pos <- currentPosition
-  r <- m
-  if p r then return r else failureOfPosition pos
-
--- | 'satisfyingP' is like 'satisfying' but applies the predicate to the
--- second item of the pair.
-satisfyingP :: MonadParser m
-            => m (P.Positioned a) -> (a -> Bool) -> m (P.Positioned a)
--- satisfyingP m p = satisfying m (p . snd)
--- This would return a better error position:
-satisfyingP m p = do
-  posr@(pos, r) <- m
-  if p r then return posr else failureOfPosition pos
-
--- | @notFollowedBy m@ succeeds if @m@ fails. If @m@ succeeds, it is
--- equivalent to 'failure'.
-notFollowedBy :: MonadParser m => m a -> m ()
-notFollowedBy m = do
-  pos <- currentPosition
-  let m' = m >> return (failureOfPosition pos)
-  join $ catchError m' (const $ return $ return ())
-
--- | @some' a@ is like @some a@, but returns a NonEmpty list.
-some' :: MonadParser m => m a -> m (NonEmpty a)
-some' a = (:|) <$> a <*> many a
-
--- | Monad wrapper that instantiates 'MonadParser' from 'MonadInput' and
--- 'MonadError'.
---
--- As an instance of 'Functor', 'Foldable', 'Applicative' and 'Monad',
--- @ParserT m@ behaves the same as the original monad @m@. The 'Alternative'
--- instance for @ParserT@ is constructed from the 'MonadError' instance to
--- obey the 'MonadParser' laws.
-newtype ParserT m a = ParserT (m a)
-  deriving (Eq, Show)
-
--- | Returns the value of 'ParserT'.
-runParserT :: ParserT m a -> m a
-runParserT (ParserT m) = m
-
--- | Directly modifies the value of 'ParserT'.
-mapParserT :: (m a -> n b) -> ParserT m a -> ParserT n b
-mapParserT f = ParserT . f . runParserT
-
-instance Functor m => Functor (ParserT m) where
-  fmap f = ParserT . fmap f . runParserT
-  a <$ ParserT b = ParserT (a <$ b)
-
-instance Foldable m => Foldable (ParserT m) where
-  fold = fold . runParserT
-  foldMap f = foldMap f . runParserT
-  foldr f z = foldr f z . runParserT
-  foldr' f z = foldr' f z . runParserT
-  foldl f z = foldl f z . runParserT
-  foldl' f z = foldl' f z . runParserT
-  foldr1 f = foldr1 f . runParserT
-  foldl1 f = foldl1 f . runParserT
-  toList = toList . runParserT
-  null = null . runParserT
-  length = length . runParserT
-  elem e = elem e . runParserT
-  maximum = maximum . runParserT
-  minimum = minimum . runParserT
-  sum = sum . runParserT
-  product = product . runParserT
-
-instance Applicative m => Applicative (ParserT m) where
-  pure = ParserT . pure
-  ParserT a <*> ParserT b = ParserT (a <*> b)
-  ParserT a  *> ParserT b = ParserT (a  *> b)
-  ParserT a <*  ParserT b = ParserT (a <*  b)
-
-instance Monad m => Monad (ParserT m) where
-  return = ParserT . return
-  ParserT a >>= f = ParserT (a >>= runParserT . f)
-  ParserT a >> ParserT b = ParserT (a >> b)
-
-instance MonadTrans ParserT where
-  lift = ParserT
-
-instance MonadInput m => MonadInput (ParserT m) where
-  popChar = lift popChar
-  lookahead = mapParserT lookahead
-  peekChar = lift peekChar
-  pushChars = lift <$> pushChars
-
-instance MonadError e m => MonadError e (ParserT m) where
-  throwError = ParserT . throwError
-  catchError (ParserT m) f = ParserT (catchError m (runParserT . f))
-
-instance (MonadInput m, MonadError Failure m)
-    => Alternative (ParserT m) where
-  empty = failure
-  a <|> b =
-    a `catchError` handle
-      where handle (Soft, _) = b
-            handle e = throwError e
-
-instance (MonadInput m, MonadError Failure m) => MonadPlus (ParserT m)
-
-instance (MonadInput m, MonadError Failure m) => MonadParser (ParserT m)
-
-instance MonadReader r m => MonadReader r (ParserT m) where
-  ask = lift ask
-  local f = mapParserT $ local f
-  reader = lift . reader
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Parser/HereDoc.hs
+++ b/src/Flesh/Language/Parser/HereDoc.hs
@@ -54,6 +54,7 @@ module Flesh.Language.Parser.HereDoc (
 import Control.Applicative
 import Control.Monad.State.Strict
 import Data.List.NonEmpty (NonEmpty(..))
+import Flesh.Language.Parser.Class
 import Flesh.Language.Parser.Error
 import Flesh.Language.Parser.Input
 import Flesh.Language.Syntax

--- a/src/Flesh/Language/Parser/Lex.hs
+++ b/src/Flesh/Language/Parser/Lex.hs
@@ -35,6 +35,7 @@ import Data.Char
 import qualified Data.List.NonEmpty as NE
 import Flesh.Source.Position
 import Flesh.Language.Parser.Char
+import Flesh.Language.Parser.Class
 import Flesh.Language.Parser.Error
 import Flesh.Language.Parser.Input
 import Numeric.Natural

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -49,6 +49,7 @@ import qualified Data.Text as T
 import qualified Flesh.Language.Alias as Alias
 import Flesh.Language.Parser.Alias
 import Flesh.Language.Parser.Char
+import Flesh.Language.Parser.Class
 import Flesh.Language.Parser.Error
 import Flesh.Language.Parser.HereDoc
 import Flesh.Language.Parser.Input

--- a/src/Flesh/Language/Pretty.hs
+++ b/src/Flesh/Language/Pretty.hs
@@ -35,6 +35,7 @@ import Control.Monad.Reader
 import Control.Monad.State.Strict
 import Data.Map.Lazy
 import Flesh.Language.Parser.Char
+import Flesh.Language.Parser.Class
 import Flesh.Language.Parser.Error
 import Flesh.Language.Parser.Input
 import Flesh.Language.Parser.Syntax


### PR DESCRIPTION
This PR updates the automated tests so that we can ensure the parser does not request any input more than needed.

- [x] Split the `Flesh.Language.Parser.Class` module from the `Flesh.Language.Parser.Error` module.
- [x] Add input error to error `Reason`.
- [ ] Define `instance MonadError Failure m => MonadInput (StateT [P.Positioned Char] m)`.
- [ ] Reimplement test utilities using the new `MonadInput`.
- [ ] Add/modify test cases to ensure the parser does not request any input more than needed.