### PR TITLE
Testing for unnecessary input requesting

### DIFF
--- a/hspec-src/Flesh/Language/Parser/AliasSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/AliasSpec.hs
@@ -45,7 +45,7 @@ testSubstituteAlias result remainder l s t v =
       pos' = dummyPosition ""
       def = definition s' v' pos'
       defs = M.singleton s' def
-      run m = fmap fst (runTesterAlias m defs l')
+      run m = fmap fst (runFullInputTesterAlias m defs l')
       subst = ParserT $ runMaybeT $ substituteAlias pos' t'
    in run subst === Right result .&&.
         run (subst >> readAll) === Right remainder
@@ -69,7 +69,7 @@ spec = do
           sSit = Alias lPos def
           sFrag = Fragment "" sSit 0
           sPos = Position sFrag 0
-          run m = fmap fst (runTesterAlias m defs pl)
+          run m = fmap fst (runFullInputTesterAlias m defs pl)
           subst = ParserT $ runMaybeT $ substituteAlias sPos n'
        in run subst === Right Nothing .&&. run (subst >> readAll) === Right l
 

--- a/hspec-src/Flesh/Language/Parser/LexSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/LexSpec.hs
@@ -37,14 +37,15 @@ spec = do
       not ("#" `isPrefixOf` s) && not ("\\\n" `isPrefixOf` s) ==>
         let p = dummyPosition s
             s' = spread p s
-         in runTester comment s' === Left (Soft, Error UnknownReason p)
+         in runFullInputTester comment s' ===
+              Left (Soft, Error UnknownReason p)
 
     prop "parses up to newline" $ \s s' ->
       not (elem '\n' s) ==>
         let input = '#' : s ++ '\n' : s'
             p = dummyPosition input
             input' = spread p input
-            e = runTester comment input'
+            e = runFullInputTester comment input'
             out = unposition $ spread (next p) s
          in e === Right (out, dropP (length s + 1) input')
 
@@ -53,7 +54,7 @@ spec = do
         let input = '#' : s
             p = dummyPosition input
             input' = spread p input
-            e = runTester comment input'
+            e = runFullInputTester comment input'
             out = unposition $ spread (next p) s
          in e === Right (out, dropP (length s + 1) input')
 

--- a/hspec-src/Flesh/Language/Parser/LexSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/LexSpec.hs
@@ -44,10 +44,10 @@ spec = do
       not (elem '\n' s) ==>
         let input = '#' : s ++ '\n' : s'
             p = dummyPosition input
-            input' = spread p input
-            e = runFullInputTester comment input'
+            input' = unposition $ spread p input
+            e = runOverrunTester comment input'
             out = unposition $ spread (next p) s
-         in e === Right (out, dropP (length s + 1) input')
+         in e === Just (Right (out, drop (length s + 1) input'))
 
     prop "parses up to end-of-file" $ \s ->
       not (elem '\n' s) ==>
@@ -62,70 +62,70 @@ spec = do
       expectSuccessEof "\\\n\\\n#" "" comment []
 
     context "ignores line continuations in comment body" $ do
-      expectSuccessEof "#\\" "\n" (fmap (fmap snd) comment) "\\"
+      expectSuccess "#\\" "\n" (fmap (fmap snd) comment) "\\"
 
   describe "whites" $ do
     context "does not skip newline" $ do
-      expectSuccessEof "" "\n" ("" <$ whites) ""
+      expectSuccess "" "\n" ("" <$ whites) ""
 
   describe "anyOperator" $ do
     context "parses control operator" $ do
       expectSuccessEof ";"  ""  (snd <$> anyOperator) ";"
-      expectSuccessEof ";"  "&" (snd <$> anyOperator) ";"
+      expectSuccess    ";"  "&" (snd <$> anyOperator) ";"
       expectSuccess    ";;" ""  (snd <$> anyOperator) ";;"
       expectSuccessEof "|"  ""  (snd <$> anyOperator) "|"
       expectSuccessEof "|"  "&" (snd <$> anyOperator) "|"
       expectSuccess    "||" ""  (snd <$> anyOperator) "||"
       expectSuccessEof "&"  ""  (snd <$> anyOperator) "&"
-      expectSuccessEof "&"  "|" (snd <$> anyOperator) "&"
+      expectSuccess    "&"  "|" (snd <$> anyOperator) "&"
       expectSuccess    "&&" ""  (snd <$> anyOperator) "&&"
       expectSuccess    "("  ""  (snd <$> anyOperator) "("
       expectSuccess    ")"  ""  (snd <$> anyOperator) ")"
 
     context "parses redirection operator" $ do
       expectSuccessEof "<"   ""  (snd <$> anyOperator) "<"
-      expectSuccessEof "<"   "-" (snd <$> anyOperator) "<"
-      expectSuccessEof "<"   "|" (snd <$> anyOperator) "<"
+      expectSuccess    "<"   "-" (snd <$> anyOperator) "<"
+      expectSuccess    "<"   "|" (snd <$> anyOperator) "<"
       expectSuccessEof "<<"  ""  (snd <$> anyOperator) "<<"
-      expectSuccessEof "<<"  "|" (snd <$> anyOperator) "<<"
+      expectSuccess    "<<"  "|" (snd <$> anyOperator) "<<"
       expectSuccess    "<<-" ""  (snd <$> anyOperator) "<<-"
       expectSuccess    "<>"  ""  (snd <$> anyOperator) "<>"
       expectSuccess    "<&"  ""  (snd <$> anyOperator) "<&"
       expectSuccessEof ">"   ""  (snd <$> anyOperator) ">"
-      expectSuccessEof ">"   "-" (snd <$> anyOperator) ">"
+      expectSuccess    ">"   "-" (snd <$> anyOperator) ">"
       expectSuccess    ">>"  ""  (snd <$> anyOperator) ">>"
       expectSuccess    ">|"  ""  (snd <$> anyOperator) ">|"
       expectSuccess    ">&"  ""  (snd <$> anyOperator) ">&"
 
     context "skips line continuations" $ do
-      expectSuccessEof "\\\n&\\\n\\\n&"  "\\\n" (snd <$> anyOperator) "&&"
-      expectSuccessEof "\\\n<\\\n<\\\n-" "\\\n" (snd <$> anyOperator) "<<-"
+      expectSuccess "\\\n&\\\n\\\n&"  "\\\n" (snd <$> anyOperator) "&&"
+      expectSuccess "\\\n<\\\n<\\\n-" "\\\n" (snd <$> anyOperator) "<<-"
 
   describe "operator" $ do
     context "parses argument control operator" $ do
       expectSuccessEof ";"  ""  (snd <$> operator ";")  ";"
-      expectSuccessEof ";"  "&" (snd <$> operator ";")  ";"
+      expectSuccess    ";"  "&" (snd <$> operator ";")  ";"
       expectSuccess    ";;" ""  (snd <$> operator ";;") ";;"
       expectSuccessEof "|"  ""  (snd <$> operator "|")  "|"
-      expectSuccessEof "|"  "&" (snd <$> operator "|")  "|"
+      expectSuccess    "|"  "&" (snd <$> operator "|")  "|"
       expectSuccess    "||" ""  (snd <$> operator "||") "||"
       expectSuccessEof "&"  ""  (snd <$> operator "&")  "&"
-      expectSuccessEof "&"  "|" (snd <$> operator "&")  "&"
+      expectSuccess    "&"  "|" (snd <$> operator "&")  "&"
       expectSuccess    "&&" ""  (snd <$> operator "&&") "&&"
       expectSuccess    "("  ""  (snd <$> operator "(")  "("
       expectSuccess    ")"  ""  (snd <$> operator ")")  ")"
 
     context "parses argument redirection operator" $ do
       expectSuccessEof "<"   ""  (snd <$> operator "<")   "<"
-      expectSuccessEof "<"   "-" (snd <$> operator "<")   "<"
-      expectSuccessEof "<"   "|" (snd <$> operator "<")   "<"
+      expectSuccess    "<"   "-" (snd <$> operator "<")   "<"
+      expectSuccess    "<"   "|" (snd <$> operator "<")   "<"
       expectSuccessEof "<<"  ""  (snd <$> operator "<<")  "<<"
-      expectSuccessEof "<<"  "|" (snd <$> operator "<<")  "<<"
+      expectSuccess    "<<"  "|" (snd <$> operator "<<")  "<<"
       expectSuccess    "<<-" ""  (snd <$> operator "<<-") "<<-"
       expectSuccess    "<>"  ""  (snd <$> operator "<>")  "<>"
       expectSuccess    "<&"  ""  (snd <$> operator "<&")  "<&"
       expectSuccessEof ">"   ""  (snd <$> operator ">")   ">"
-      expectSuccessEof ">"   "-" (snd <$> operator ">")   ">"
+      expectSuccess    ">"   "-" (snd <$> operator ">")   ">"
       expectSuccess    ">>"  ""  (snd <$> operator ">>")  ">>"
       expectSuccess    ">|"  ""  (snd <$> operator ">|")  ">|"
       expectSuccess    ">&"  ""  (snd <$> operator ">&")  ">&"
@@ -138,16 +138,16 @@ spec = do
       expectFailure    "<<-" (operator "<")  Soft UnknownReason 0
       expectFailure    "<<-" (operator "<<") Soft UnknownReason 0
       expectFailure    "<>"  (operator "<<") Soft UnknownReason 0
-      expectFailureEof ">>"  (operator ">")  Soft UnknownReason 0
+      expectFailure    ">>"  (operator ">")  Soft UnknownReason 0
       expectFailure    ">|"  (operator ">")  Soft UnknownReason 0
       expectFailure    ">&"  (operator ">")  Soft UnknownReason 0
       expectFailure    "\\\n>&" (operator ">") Soft UnknownReason 2
 
   describe "ioNumber" $ do
     context "parses digits followed by < or >" $ do
-      expectSuccessEof "1" "<" ioNumber 1
-      expectSuccessEof "20" ">" ioNumber 20
-      expectSuccessEof "123" ">" ioNumber 123
+      expectSuccess "1" "<" ioNumber 1
+      expectSuccess "20" ">" ioNumber 20
+      expectSuccess "123" ">" ioNumber 123
 
     context "rejects non-digits" $ do
       expectFailure "<" ioNumber Soft UnknownReason 0

--- a/hspec-src/Flesh/Language/Parser/LexSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/LexSpec.hs
@@ -24,13 +24,13 @@ import Flesh.Language.Parser.TestUtil
 import Flesh.Source.Position
 import Test.Hspec
 import Test.Hspec.QuickCheck
-import Test.QuickCheck
+import Test.QuickCheck hiding (expectFailure)
 
 spec :: Spec
 spec = do
   describe "blank" $ do
     context "does not accept newline" $ do
-      expectFailureEof "\n" blank Soft UnknownReason 0
+      expectFailure "\n" blank Soft UnknownReason 0
 
   describe "comment" $ do
     prop "fails if input does not start with #" $ \s ->
@@ -131,17 +131,17 @@ spec = do
       expectSuccess    ">&"  ""  (snd <$> operator ">&")  ">&"
 
     context "rejects operator other than argument" $ do
-      expectFailureEof ";;"  (operator ";")  Soft UnknownReason 0
-      expectFailureEof "&&"  (operator "&")  Soft UnknownReason 0
-      expectFailureEof "||"  (operator "|")  Soft UnknownReason 0
+      expectFailure    ";;"  (operator ";")  Soft UnknownReason 0
+      expectFailure    "&&"  (operator "&")  Soft UnknownReason 0
+      expectFailure    "||"  (operator "|")  Soft UnknownReason 0
       expectFailureEof "<<"  (operator "<")  Soft UnknownReason 0
-      expectFailureEof "<<-" (operator "<")  Soft UnknownReason 0
-      expectFailureEof "<<-" (operator "<<") Soft UnknownReason 0
-      expectFailureEof "<>"  (operator "<<") Soft UnknownReason 0
+      expectFailure    "<<-" (operator "<")  Soft UnknownReason 0
+      expectFailure    "<<-" (operator "<<") Soft UnknownReason 0
+      expectFailure    "<>"  (operator "<<") Soft UnknownReason 0
       expectFailureEof ">>"  (operator ">")  Soft UnknownReason 0
-      expectFailureEof ">|"  (operator ">")  Soft UnknownReason 0
-      expectFailureEof ">&"  (operator ">")  Soft UnknownReason 0
-      expectFailureEof "\\\n>&"  (operator ">")  Soft UnknownReason 2
+      expectFailure    ">|"  (operator ">")  Soft UnknownReason 0
+      expectFailure    ">&"  (operator ">")  Soft UnknownReason 0
+      expectFailure    "\\\n>&" (operator ">") Soft UnknownReason 2
 
   describe "ioNumber" $ do
     context "parses digits followed by < or >" $ do
@@ -150,18 +150,18 @@ spec = do
       expectSuccessEof "123" ">" ioNumber 123
 
     context "rejects non-digits" $ do
-      expectFailureEof "<" ioNumber Soft UnknownReason 0
-      expectFailureEof "a" ioNumber Soft UnknownReason 0
-      expectFailureEof " " ioNumber Soft UnknownReason 0
+      expectFailure "<" ioNumber Soft UnknownReason 0
+      expectFailure "a" ioNumber Soft UnknownReason 0
+      expectFailure " " ioNumber Soft UnknownReason 0
 
     context "rejects digits not followed by < or >" $ do
       expectFailureEof "0" ioNumber Soft UnknownReason 1
-      expectFailureEof "1-" ioNumber Soft UnknownReason 1
-      expectFailureEof "23 " ioNumber Soft UnknownReason 2
+      expectFailure    "1-" ioNumber Soft UnknownReason 1
+      expectFailure    "23 " ioNumber Soft UnknownReason 2
 
     context "skips line continuations" $ do
-      expectSuccessEof "\\\n\\\n1" "<" ioNumber 1
-      expectSuccessEof "1" "\\\n\\\n<" ioNumber 1
-      expectFailureEof "1\\\n-" ioNumber Soft UnknownReason 3
+      expectSuccess "\\\n\\\n1" "<" ioNumber 1
+      expectSuccess "1" "\\\n\\\n<" ioNumber 1
+      expectFailure "1\\\n-" ioNumber Soft UnknownReason 3
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -107,17 +107,18 @@ spec = do
 
   describe "aliasableToken" $ do
     let at = runAliasT aliasableToken
+        at' = runAliasT aliasableToken
 
     context "returns unmatched token" $ do
-      expectShow "foo" ";" at "Just foo"
+      expectShow "foo" ";" at' "Just foo"
 
     context "returns quoted token" $ do
-      expectShow "f\\oo" ";" at "Just f\\oo"
-      expectShow "f\"o\"o" "&" at "Just f\"o\"o"
-      expectShow "f'o'o" ")" at "Just f'o'o"
+      expectShow "f\\oo" ";" at' "Just f\\oo"
+      expectShow "f\"o\"o" "&" at' "Just f\"o\"o"
+      expectShow "f'o'o" ")" at' "Just f'o'o"
 
     context "returns non-constant token" $ do
-      expectShow "f${1}o" ";" at "Just f${1}o"
+      expectShow "f${1}o" ";" at' "Just f${1}o"
 
     context "modifies pending input" $ do
       expectSuccessEof defaultAliasName "" (at >> readAll) defaultAliasValue
@@ -302,6 +303,7 @@ spec = do
 
   describe "andOrList" $ do
     let aol = runAliasT $ fill andOrList
+        aol' = runAliasT $ fill andOrList
 
     context "consists of pipelines" $ do
       expectShowEof "foo;" "" aol "Just foo;"
@@ -316,16 +318,16 @@ spec = do
         "Just foo && ! bar || baz&"
 
     context "can end before newline" $ do
-      expectShow "foo" "\n" aol "Just foo;"
-      expectShow "foo && bar" "\n" aol "Just foo && bar;"
+      expectShow "foo" "\n" aol' "Just foo;"
+      expectShow "foo && bar" "\n" aol' "Just foo && bar;"
       context "cannot have newlines before && or ||" $ do
         expectShowEof "foo" "\n&&bar" aol "Just foo;"
         expectShowEof "foo" "\n||bar" aol "Just foo;"
 
     context "can end before operators" $ do
-      expectShow "foo" ";;" aol "Just foo;"
-      expectShow "foo" "("  aol "Just foo;"
-      expectShow "foo" ")"  aol "Just foo;"
+      expectShow "foo" ";;" aol' "Just foo;"
+      expectShow "foo" "("  aol' "Just foo;"
+      expectShow "foo" ")"  aol' "Just foo;"
 
     context "can end at end of input" $ do
       expectShowEof "foo" "" aol "Just foo;"

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -102,8 +102,7 @@ spec = do
       expectShow "a\\\nX" "" (tokenTill (lc (char 'X'))) "a"
 
     context "rejects empty token" $ do
-      expectFailureEof "\\\n)" (tokenTill (lc (char ')')))
-        Soft UnknownReason 0
+      expectFailure "\\\n)" (tokenTill (lc (char ')'))) Soft UnknownReason 0
 
   describe "aliasableToken" $ do
     let at = runAliasT aliasableToken
@@ -264,6 +263,7 @@ spec = do
 
   describe "pipeline" $ do
     let p = runAliasT $ fill pipeline
+        p' = runAliasT $ fill pipeline
 
     context "can start with !" $ do
       expectShowEof "! foo bar " "\n" p "Just ! foo bar"
@@ -274,11 +274,12 @@ spec = do
       expectShowEof "\\\nnew" "" p "Just new"
 
     context "requires command after !" $ do
-      expectFailureEof "!" p Hard (MissingCommandAfter "!") 1
-      expectFailureEof "! ;" p Hard (MissingCommandAfter "!") 2
+      expectFailureEof "!"   p  Hard (MissingCommandAfter "!") 1
+      expectFailure    "! ;" p' Hard (MissingCommandAfter "!") 2
 
   describe "conditionalPipeline" $ do
     let cp = runAliasT $ fill conditionalPipeline
+        cp' = runAliasT $ fill conditionalPipeline
 
     context "can start with && followed by pipeline" $ do
       expectShowEof "&&foo" "" cp "Just && foo"
@@ -293,13 +294,13 @@ spec = do
       expectShowEof "|| \n \n foo" ";" cp "Just || foo"
 
     context "requires pipeline after operator" $ do
-      expectFailureEof "&&"    cp Hard (MissingCommandAfter "&&") 2
-      expectFailureEof "||\n;" cp Hard (MissingCommandAfter "||") 3
+      expectFailureEof "&&"    cp  Hard (MissingCommandAfter "&&") 2
+      expectFailure    "||\n;" cp' Hard (MissingCommandAfter "||") 3
 
     context "must start with operator" $ do
-      expectFailureEof "foo" cp Soft UnknownReason 0
-      expectFailureEof "! bar" cp Soft UnknownReason 0
-      expectFailureEof ";" cp Soft UnknownReason 0
+      expectFailure    "foo"   cp' Soft UnknownReason 0
+      expectFailure    "! bar" cp' Soft UnknownReason 0
+      expectFailureEof ";"     cp  Soft UnknownReason 0
 
   describe "andOrList" $ do
     let aol = runAliasT $ fill andOrList
@@ -357,8 +358,8 @@ spec = do
     context "fails with incomplete line" $ do
       expectFailureEof ";"      completeLine Hard UnknownReason 0
       expectFailureEof "&"      completeLine Hard UnknownReason 0
-      expectFailureEof "foo;&"  completeLine Hard UnknownReason 4
-      expectFailureEof "foo("   completeLine Hard UnknownReason 3
+      expectFailure    "foo;&"  completeLine Hard UnknownReason 4
+      expectFailure    "foo("   completeLine Hard UnknownReason 3
       expectFailureEof "foo& ;" completeLine Hard UnknownReason 5
       expectFailureEof "foo;;"  completeLine Hard UnknownReason 3
 

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -123,17 +123,17 @@ spec = do
       expectSuccessEof defaultAliasName "" (at >> readAll) defaultAliasValue
 
     it "returns nothing after substitution" $
-      let e = runTesterWithDummyPositions at defaultAliasName
+      let e = runFullInputTesterWithDummyPositions at defaultAliasName
        in fmap fst e `shouldBe` Right Nothing
 
     it "stops on recursion" $
-      let e = runTesterWithDummyPositions (reparse aliasableToken >> readAll)
-                defaultAliasName
+      let e = runFullInputTesterWithDummyPositions
+                (reparse aliasableToken >> readAll) defaultAliasName
        in fmap fst e `shouldBe` Right "--color"
 
     it "stops on exact recursion" $
-      let e = runTesterWithDummyPositions (reparse aliasableToken >> readAll)
-                recursiveAlias
+      let e = runFullInputTesterWithDummyPositions
+                (reparse aliasableToken >> readAll) recursiveAlias
        in fmap fst e `shouldBe` Right ""
 
   describe "reserved" $ do
@@ -236,7 +236,7 @@ spec = do
       expectFailureEof "" sc Soft UnknownReason 0
 
     it "returns nothing after alias substitution" $
-      let e = runTesterWithDummyPositions sc defaultAliasName
+      let e = runFullInputTesterWithDummyPositions sc defaultAliasName
        in fmap fst e `shouldBe` Right Nothing
 
     context "does not alias-substitute second token" $ do
@@ -369,7 +369,7 @@ spec = do
             (Pipeline (SimpleCommand [] [] [HereDoc _ c] :| _) _) _ _] =
               Just c
           f _ = Nothing
-          p = runTesterWithDummyPositions (f <$> completeLine)
+          p = runFullInputTesterWithDummyPositions (f <$> completeLine)
 
       it "fills empty here document content" $
         fmap fst (p "<<X\nX\n") `shouldBe` Right (Just [])

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -275,7 +275,7 @@ spec = do
 
     context "requires command after !" $ do
       expectFailureEof "!"   p  Hard (MissingCommandAfter "!") 1
-      expectFailure    "! ;" p' Hard (MissingCommandAfter "!") 2
+      expectFailure    "! )" p' Hard (MissingCommandAfter "!") 2
 
   describe "conditionalPipeline" $ do
     let cp = runAliasT $ fill conditionalPipeline
@@ -295,7 +295,7 @@ spec = do
 
     context "requires pipeline after operator" $ do
       expectFailureEof "&&"    cp  Hard (MissingCommandAfter "&&") 2
-      expectFailure    "||\n;" cp' Hard (MissingCommandAfter "||") 3
+      expectFailure    "||\n)" cp' Hard (MissingCommandAfter "||") 3
 
     context "must start with operator" $ do
       expectFailure    "foo"   cp' Soft UnknownReason 0
@@ -321,9 +321,11 @@ spec = do
     context "can end before newline" $ do
       expectShow "foo" "\n" aol' "Just foo;"
       expectShow "foo && bar" "\n" aol' "Just foo && bar;"
+{- These special cases are covered by the case above
       context "cannot have newlines before && or ||" $ do
         expectShowEof "foo" "\n&&bar" aol "Just foo;"
         expectShowEof "foo" "\n||bar" aol "Just foo;"
+-}
 
     context "can end before operators" $ do
       expectShow "foo" ";;" aol' "Just foo;"
@@ -358,8 +360,8 @@ spec = do
     context "fails with incomplete line" $ do
       expectFailureEof ";"      completeLine Hard UnknownReason 0
       expectFailureEof "&"      completeLine Hard UnknownReason 0
-      expectFailure    "foo;&"  completeLine Hard UnknownReason 4
-      expectFailure    "foo("   completeLine Hard UnknownReason 3
+      expectFailure    "foo;& " completeLine Hard UnknownReason 4
+      expectFailure    "foo)"   completeLine Hard UnknownReason 3
       expectFailureEof "foo& ;" completeLine Hard UnknownReason 5
       expectFailureEof "foo;;"  completeLine Hard UnknownReason 3
 

--- a/hspec-src/Flesh/Language/Parser/TestUtil.hs
+++ b/hspec-src/Flesh/Language/Parser/TestUtil.hs
@@ -119,14 +119,14 @@ runTesterWithDummyPositions parser s = runTester parser s'
 readAll :: MonadParser m => m String
 readAll = fmap (fmap snd) (many anyChar)
 
--- | @expectSuccessEof consumed lookahead parser result@ runs the given
--- @parser@ for the source code @consumed ++ lookahead@ and tests if the
+-- | @expectSuccessEof consumed unconsumed parser result@ runs the given
+-- @parser@ for the source code @consumed ++ unconsumed@ and tests if the
 -- expected @result@ is returned and if the expected @consumed@ part of the
 -- code is actually consumed.
 expectSuccessEof :: (Eq a, Show a) =>
   String -> String -> Tester a -> a -> SpecWith ()
-expectSuccessEof consumed lookahead parser result =
-  let s = consumed ++ lookahead
+expectSuccessEof consumed unconsumed parser result =
+  let s = consumed ++ unconsumed
       s' = spread (dummyPosition s) s
       e = runTester parser s'
    in context s $ do
@@ -139,10 +139,10 @@ expectSuccessEof consumed lookahead parser result =
 -- | Like 'expectSuccessEof', but tries many arbitrary remainders.
 expectSuccess :: (Eq a, Show a) =>
   String -> String -> Tester a -> a -> SpecWith ()
-expectSuccess consumed lookahead parser result =
-  context (consumed ++ lookahead ++ "...") $
+expectSuccess consumed unconsumed parser result =
+  context (consumed ++ unconsumed ++ "...") $
     prop "returns expected result and state" $ \remainder ->
-      let s = consumed ++ lookahead ++ remainder
+      let s = consumed ++ unconsumed ++ remainder
           s' = spread (dummyPosition s) s
           e = runTester parser s'
        in e === Right (result, dropP (length consumed) s')
@@ -174,13 +174,13 @@ expectPosition input parser expectedPositionIndex =
 -- with the given expected string.
 expectShowEof :: Show a =>
   String -> String -> Tester a -> String -> SpecWith ()
-expectShowEof consumed lookahead parser =
-  expectSuccessEof consumed lookahead (show <$> parser)
+expectShowEof consumed unconsumed parser =
+  expectSuccessEof consumed unconsumed (show <$> parser)
 
 -- | Like 'expectShowEof', but tries many arbitrary remainders.
 expectShow :: Show a => String -> String -> Tester a -> String -> SpecWith ()
-expectShow consumed lookahead parser =
-  expectSuccess consumed lookahead (show <$> parser)
+expectShow consumed unconsumed parser =
+  expectSuccess consumed unconsumed (show <$> parser)
 
 -- | @expectFailureEof input parser severity reason position@ runs the given
 -- @parser@ for the given @input@ and tests if it fails for the expected error

--- a/hspec-src/Flesh/Language/Parser/TestUtil.hs
+++ b/hspec-src/Flesh/Language/Parser/TestUtil.hs
@@ -78,8 +78,9 @@ instance MonadInput (StateT [Positioned Char] Overrun) where
 
   pushChars cs = modify' (cs ++)
 
-type Tester = ParserT (ReaderT Alias.DefinitionSet
-  (StateT PositionedString (ExceptT Failure Identity)))
+type TesterT m = ParserT (ReaderT Alias.DefinitionSet m)
+type OverrunTester = TesterT (StateT [Positioned Char] Overrun)
+type FullInputTester = TesterT (StateT PositionedString (Except Failure))
 
 defaultAliasName :: String
 defaultAliasName = "ls"
@@ -100,20 +101,24 @@ defaultAliasDefinitions =
             r = T.pack recursiveAlias
             pr = dummyPosition "alias rec=rec"
 
-runTesterAlias :: Tester a -> Alias.DefinitionSet -> PositionedString
-               -> Either Failure (a, PositionedString)
-runTesterAlias parser defs ps =
-  runIdentity $ runExceptT $ runStateT p1 ps
-    where p1 = runReaderT p2 defs
-          p2 = runParserT parser
+runTesterAliasT :: TesterT m a -> Alias.DefinitionSet -> m a
+runTesterAliasT parser defs = runReaderT (runParserT parser) defs
 
-runTester :: Tester a -> PositionedString
-          -> Either Failure (a, PositionedString)
-runTester parser = runTesterAlias parser defaultAliasDefinitions
+runFullInputTesterAlias :: FullInputTester a
+                        -> Alias.DefinitionSet -> PositionedString
+                        -> Either Failure (a, PositionedString)
+runFullInputTesterAlias parser defs ps =
+  runIdentity $ runExceptT $ runStateT (runTesterAliasT parser defs) ps
+    
 
-runTesterWithDummyPositions :: Tester a -> String
+runFullInputTester :: FullInputTester a -> PositionedString
+                   -> Either Failure (a, PositionedString)
+runFullInputTester parser =
+  runFullInputTesterAlias parser defaultAliasDefinitions
+
+runFullInputTesterWithDummyPositions :: FullInputTester a -> String
                             -> Either Failure (a, PositionedString)
-runTesterWithDummyPositions parser s = runTester parser s'
+runFullInputTesterWithDummyPositions parser s = runFullInputTester parser s'
   where s' = spread (dummyPosition s) s
 
 readAll :: MonadParser m => m String
@@ -124,11 +129,11 @@ readAll = fmap (fmap snd) (many anyChar)
 -- expected @result@ is returned and if the expected @consumed@ part of the
 -- code is actually consumed.
 expectSuccessEof :: (Eq a, Show a) =>
-  String -> String -> Tester a -> a -> SpecWith ()
+  String -> String -> FullInputTester a -> a -> SpecWith ()
 expectSuccessEof consumed unconsumed parser result =
   let s = consumed ++ unconsumed
       s' = spread (dummyPosition s) s
-      e = runTester parser s'
+      e = runFullInputTester parser s'
    in context s $ do
      it "returns expected result successfully" $
        fmap fst e `shouldBe` Right result
@@ -138,47 +143,48 @@ expectSuccessEof consumed unconsumed parser result =
 
 -- | Like 'expectSuccessEof', but tries many arbitrary remainders.
 expectSuccess :: (Eq a, Show a) =>
-  String -> String -> Tester a -> a -> SpecWith ()
+  String -> String -> FullInputTester a -> a -> SpecWith ()
 expectSuccess consumed unconsumed parser result =
   context (consumed ++ unconsumed ++ "...") $
     prop "returns expected result and state" $ \remainder ->
       let s = consumed ++ unconsumed ++ remainder
           s' = spread (dummyPosition s) s
-          e = runTester parser s'
+          e = runFullInputTester parser s'
        in e === Right (result, dropP (length consumed) s')
 
 -- | @expectPositionEof input parser expectedPositionIndex@ runs the given
 -- @parser@ for the given @input@ and tests if the result is a position at the
 -- given index withing the input.
-expectPositionEof :: String -> Tester Position -> Int -> SpecWith ()
+expectPositionEof :: String -> FullInputTester Position -> Int -> SpecWith ()
 expectPositionEof input parser expectedPositionIndex =
   let s' = spread (dummyPosition input) input
-      e = runTester parser s'
+      e = runFullInputTester parser s'
       expectedPosition = headPosition (dropP expectedPositionIndex s')
    in context input $ do
      it "returns expected position" $
        fmap fst e `shouldBe` Right expectedPosition
 
 -- | Like 'expectPositionEof', but tries many arbitrary remainders.
-expectPosition :: String -> Tester Position -> Int -> SpecWith ()
+expectPosition :: String -> FullInputTester Position -> Int -> SpecWith ()
 expectPosition input parser expectedPositionIndex =
   context (input ++ "...") $
     prop "returns expected position" $ \remainder ->
       let s = input ++ remainder
           s' = spread (dummyPosition s) s
-          e = runTester parser s'
+          e = runFullInputTester parser s'
           expectedPosition = headPosition (dropP expectedPositionIndex s')
        in fmap fst e === Right expectedPosition
 
 -- | Like 'expectSuccessEof', but compares string representation of the result
 -- with the given expected string.
 expectShowEof :: Show a =>
-  String -> String -> Tester a -> String -> SpecWith ()
+  String -> String -> FullInputTester a -> String -> SpecWith ()
 expectShowEof consumed unconsumed parser =
   expectSuccessEof consumed unconsumed (show <$> parser)
 
 -- | Like 'expectShowEof', but tries many arbitrary remainders.
-expectShow :: Show a => String -> String -> Tester a -> String -> SpecWith ()
+expectShow :: Show a
+           => String -> String -> FullInputTester a -> String -> SpecWith ()
 expectShow consumed unconsumed parser =
   expectSuccess consumed unconsumed (show <$> parser)
 
@@ -189,10 +195,10 @@ expectShow consumed unconsumed parser =
 -- Type parameter @a@ needs to be 'Show' and 'Eq'. Map to @()@ if you want to
 -- apply to a non-Show or non-Eq @a@.
 expectFailureEof :: (Eq a, Show a) =>
-  String -> Tester a -> Severity -> Reason -> Int -> SpecWith ()
+  String -> FullInputTester a -> Severity -> Reason -> Int -> SpecWith ()
 expectFailureEof input parser s r expectedPositionIndex =
   let s' = spread (dummyPosition input) input
-      e = runTester parser s'
+      e = runFullInputTester parser s'
       expectedPosition = headPosition (dropP expectedPositionIndex s')
    in context input $ do
      it "fails" $
@@ -202,10 +208,11 @@ expectFailureEof input parser s r expectedPositionIndex =
 -- predicate rather than direct comparison. This is useful when the reason
 -- cannot be easily constructed.
 expectFailureEof' :: Show a =>
-  String -> Tester a -> Severity -> (Reason -> Bool) -> Int -> SpecWith ()
+  String -> FullInputTester a -> Severity -> (Reason -> Bool) -> Int ->
+    SpecWith ()
 expectFailureEof' input parser s r expectedPositionIndex =
   let s' = spread (dummyPosition input) input
-      e = runTester parser s'
+      e = runFullInputTester parser s'
       expectedPosition = headPosition (dropP expectedPositionIndex s')
    in context input $
        case e of

--- a/hspec-src/Flesh/Language/Parser/TestUtil.hs
+++ b/hspec-src/Flesh/Language/Parser/TestUtil.hs
@@ -128,6 +128,11 @@ runFullInputTesterWithDummyPositions :: FullInputTester a -> String
 runFullInputTesterWithDummyPositions parser s = runFullInputTester parser s'
   where s' = spread (dummyPosition s) s
 
+runOverrunTesterWithDummyPositions :: OverrunTester a -> String ->
+  Maybe (Either Failure (a, [Positioned Char]))
+runOverrunTesterWithDummyPositions parser s = runOverrunTester parser s'
+  where s' = unposition $ spread (dummyPosition s) s
+
 readAll :: MonadParser m => m String
 readAll = fmap (fmap snd) (many anyChar)
 

--- a/src/Flesh/Language/Parser/Input.hs
+++ b/src/Flesh/Language/Parser/Input.hs
@@ -31,11 +31,11 @@ parser.
 module Flesh.Language.Parser.Input (
   MonadInput(..), followedBy, currentPosition) where
 
-import Flesh.Source.Position
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State.Strict
 import Control.Monad.Trans.Maybe
+import Flesh.Source.Position
 
 -- | Monad for character input operations.
 --

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -227,7 +227,7 @@ simpleCommand = f <$> nonEmptyBody
           pure ([], [], [])
         redirect' = mapHereDocT lift redirect
         aliasableToken' = lift aliasableToken
-        normalToken' = lift normalToken
+        normalToken' = lift $ lift normalToken
         fRedir r (ts, as, rs) = (ts, as, r:rs)
         fToken t (ts, as, rs) = (t:ts, as, rs)
 -- TODO global aliases


### PR DESCRIPTION
This PR updates the automated tests so that we can ensure the parser does not request any input more than needed. This is #36 done in a different way.

- [x] Define `instance MonadInput (StateT [Positioned Char] m)`.
- [x] Define `instance MonadInput (StateT [Positioned Char] Overrun)` where `newtype Overrun = Overrun (ExceptT Failure Maybe)`.
- [x] Redefine `Tester` to enable switching between the two tester types.
- [x] Reimplement test utilities using the new two tester types.
- [ ] Add/modify test cases to ensure the parser does not request any input more than needed.