### PR TITLE
Avoid reading the next line after a line is parsed

### DIFF
--- a/hspec-src/Flesh/Language/Parser/AliasSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/AliasSpec.hs
@@ -45,7 +45,7 @@ testSubstituteAlias result remainder l s t v =
       pos' = dummyPosition ""
       def = definition s' v' pos'
       defs = M.singleton s' def
-      run m = fmap fst (runTesterAlias m defs l')
+      run m = fmap fst (runFullInputTesterAlias m defs l')
       subst = ParserT $ runMaybeT $ substituteAlias pos' t'
    in run subst === Right result .&&.
         run (subst >> readAll) === Right remainder
@@ -69,7 +69,7 @@ spec = do
           sSit = Alias lPos def
           sFrag = Fragment "" sSit 0
           sPos = Position sFrag 0
-          run m = fmap fst (runTesterAlias m defs pl)
+          run m = fmap fst (runFullInputTesterAlias m defs pl)
           subst = ParserT $ runMaybeT $ substituteAlias sPos n'
        in run subst === Right Nothing .&&. run (subst >> readAll) === Right l
 

--- a/hspec-src/Flesh/Language/Parser/LexSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/LexSpec.hs
@@ -37,14 +37,15 @@ spec = do
       not ("#" `isPrefixOf` s) && not ("\\\n" `isPrefixOf` s) ==>
         let p = dummyPosition s
             s' = spread p s
-         in runTester comment s' === Left (Soft, Error UnknownReason p)
+         in runFullInputTester comment s' ===
+              Left (Soft, Error UnknownReason p)
 
     prop "parses up to newline" $ \s s' ->
       not (elem '\n' s) ==>
         let input = '#' : s ++ '\n' : s'
             p = dummyPosition input
             input' = spread p input
-            e = runTester comment input'
+            e = runFullInputTester comment input'
             out = unposition $ spread (next p) s
          in e === Right (out, dropP (length s + 1) input')
 
@@ -53,7 +54,7 @@ spec = do
         let input = '#' : s
             p = dummyPosition input
             input' = spread p input
-            e = runTester comment input'
+            e = runFullInputTester comment input'
             out = unposition $ spread (next p) s
          in e === Right (out, dropP (length s + 1) input')
 

--- a/hspec-src/Flesh/Language/Parser/LexSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/LexSpec.hs
@@ -24,13 +24,13 @@ import Flesh.Language.Parser.TestUtil
 import Flesh.Source.Position
 import Test.Hspec
 import Test.Hspec.QuickCheck
-import Test.QuickCheck
+import Test.QuickCheck hiding (expectFailure)
 
 spec :: Spec
 spec = do
   describe "blank" $ do
     context "does not accept newline" $ do
-      expectFailureEof "\n" blank Soft UnknownReason 0
+      expectFailure "\n" blank Soft UnknownReason 0
 
   describe "comment" $ do
     prop "fails if input does not start with #" $ \s ->
@@ -131,17 +131,17 @@ spec = do
       expectSuccess    ">&"  ""  (snd <$> operator ">&")  ">&"
 
     context "rejects operator other than argument" $ do
-      expectFailureEof ";;"  (operator ";")  Soft UnknownReason 0
-      expectFailureEof "&&"  (operator "&")  Soft UnknownReason 0
-      expectFailureEof "||"  (operator "|")  Soft UnknownReason 0
+      expectFailure    ";;"  (operator ";")  Soft UnknownReason 0
+      expectFailure    "&&"  (operator "&")  Soft UnknownReason 0
+      expectFailure    "||"  (operator "|")  Soft UnknownReason 0
       expectFailureEof "<<"  (operator "<")  Soft UnknownReason 0
-      expectFailureEof "<<-" (operator "<")  Soft UnknownReason 0
-      expectFailureEof "<<-" (operator "<<") Soft UnknownReason 0
-      expectFailureEof "<>"  (operator "<<") Soft UnknownReason 0
+      expectFailure    "<<-" (operator "<")  Soft UnknownReason 0
+      expectFailure    "<<-" (operator "<<") Soft UnknownReason 0
+      expectFailure    "<>"  (operator "<<") Soft UnknownReason 0
       expectFailureEof ">>"  (operator ">")  Soft UnknownReason 0
-      expectFailureEof ">|"  (operator ">")  Soft UnknownReason 0
-      expectFailureEof ">&"  (operator ">")  Soft UnknownReason 0
-      expectFailureEof "\\\n>&"  (operator ">")  Soft UnknownReason 2
+      expectFailure    ">|"  (operator ">")  Soft UnknownReason 0
+      expectFailure    ">&"  (operator ">")  Soft UnknownReason 0
+      expectFailure    "\\\n>&" (operator ">") Soft UnknownReason 2
 
   describe "ioNumber" $ do
     context "parses digits followed by < or >" $ do
@@ -150,18 +150,18 @@ spec = do
       expectSuccessEof "123" ">" ioNumber 123
 
     context "rejects non-digits" $ do
-      expectFailureEof "<" ioNumber Soft UnknownReason 0
-      expectFailureEof "a" ioNumber Soft UnknownReason 0
-      expectFailureEof " " ioNumber Soft UnknownReason 0
+      expectFailure "<" ioNumber Soft UnknownReason 0
+      expectFailure "a" ioNumber Soft UnknownReason 0
+      expectFailure " " ioNumber Soft UnknownReason 0
 
     context "rejects digits not followed by < or >" $ do
       expectFailureEof "0" ioNumber Soft UnknownReason 1
-      expectFailureEof "1-" ioNumber Soft UnknownReason 1
-      expectFailureEof "23 " ioNumber Soft UnknownReason 2
+      expectFailure    "1-" ioNumber Soft UnknownReason 1
+      expectFailure    "23 " ioNumber Soft UnknownReason 2
 
     context "skips line continuations" $ do
-      expectSuccessEof "\\\n\\\n1" "<" ioNumber 1
-      expectSuccessEof "1" "\\\n\\\n<" ioNumber 1
-      expectFailureEof "1\\\n-" ioNumber Soft UnknownReason 3
+      expectSuccess "\\\n\\\n1" "<" ioNumber 1
+      expectSuccess "1" "\\\n\\\n<" ioNumber 1
+      expectFailure "1\\\n-" ioNumber Soft UnknownReason 3
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/hspec-src/Flesh/Language/Parser/LexSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/LexSpec.hs
@@ -45,9 +45,9 @@ spec = do
         let input = '#' : s ++ '\n' : s'
             p = dummyPosition input
             input' = spread p input
-            e = runFullInputTester comment input'
+            e = runOverrunTester comment input'
             out = unposition $ spread (next p) s
-         in e === Right (out, dropP (length s + 1) input')
+         in e === Just (Right (out, dropP (length s + 1) input'))
 
     prop "parses up to end-of-file" $ \s ->
       not (elem '\n' s) ==>
@@ -62,70 +62,70 @@ spec = do
       expectSuccessEof "\\\n\\\n#" "" comment []
 
     context "ignores line continuations in comment body" $ do
-      expectSuccessEof "#\\" "\n" (fmap (fmap snd) comment) "\\"
+      expectSuccess "#\\" "\n" (fmap (fmap snd) comment) "\\"
 
   describe "whites" $ do
     context "does not skip newline" $ do
-      expectSuccessEof "" "\n" ("" <$ whites) ""
+      expectSuccess "" "\n" ("" <$ whites) ""
 
   describe "anyOperator" $ do
     context "parses control operator" $ do
       expectSuccessEof ";"  ""  (snd <$> anyOperator) ";"
-      expectSuccessEof ";"  "&" (snd <$> anyOperator) ";"
+      expectSuccess    ";"  "&" (snd <$> anyOperator) ";"
       expectSuccess    ";;" ""  (snd <$> anyOperator) ";;"
       expectSuccessEof "|"  ""  (snd <$> anyOperator) "|"
       expectSuccessEof "|"  "&" (snd <$> anyOperator) "|"
       expectSuccess    "||" ""  (snd <$> anyOperator) "||"
       expectSuccessEof "&"  ""  (snd <$> anyOperator) "&"
-      expectSuccessEof "&"  "|" (snd <$> anyOperator) "&"
+      expectSuccess    "&"  "|" (snd <$> anyOperator) "&"
       expectSuccess    "&&" ""  (snd <$> anyOperator) "&&"
       expectSuccess    "("  ""  (snd <$> anyOperator) "("
       expectSuccess    ")"  ""  (snd <$> anyOperator) ")"
 
     context "parses redirection operator" $ do
       expectSuccessEof "<"   ""  (snd <$> anyOperator) "<"
-      expectSuccessEof "<"   "-" (snd <$> anyOperator) "<"
-      expectSuccessEof "<"   "|" (snd <$> anyOperator) "<"
+      expectSuccess    "<"   "-" (snd <$> anyOperator) "<"
+      expectSuccess    "<"   "|" (snd <$> anyOperator) "<"
       expectSuccessEof "<<"  ""  (snd <$> anyOperator) "<<"
-      expectSuccessEof "<<"  "|" (snd <$> anyOperator) "<<"
+      expectSuccess    "<<"  "|" (snd <$> anyOperator) "<<"
       expectSuccess    "<<-" ""  (snd <$> anyOperator) "<<-"
       expectSuccess    "<>"  ""  (snd <$> anyOperator) "<>"
       expectSuccess    "<&"  ""  (snd <$> anyOperator) "<&"
       expectSuccessEof ">"   ""  (snd <$> anyOperator) ">"
-      expectSuccessEof ">"   "-" (snd <$> anyOperator) ">"
+      expectSuccess    ">"   "-" (snd <$> anyOperator) ">"
       expectSuccess    ">>"  ""  (snd <$> anyOperator) ">>"
       expectSuccess    ">|"  ""  (snd <$> anyOperator) ">|"
       expectSuccess    ">&"  ""  (snd <$> anyOperator) ">&"
 
     context "skips line continuations" $ do
-      expectSuccessEof "\\\n&\\\n\\\n&"  "\\\n" (snd <$> anyOperator) "&&"
-      expectSuccessEof "\\\n<\\\n<\\\n-" "\\\n" (snd <$> anyOperator) "<<-"
+      expectSuccess "\\\n&\\\n\\\n&"  "\\\n" (snd <$> anyOperator) "&&"
+      expectSuccess "\\\n<\\\n<\\\n-" "\\\n" (snd <$> anyOperator) "<<-"
 
   describe "operator" $ do
     context "parses argument control operator" $ do
       expectSuccessEof ";"  ""  (snd <$> operator ";")  ";"
-      expectSuccessEof ";"  "&" (snd <$> operator ";")  ";"
+      expectSuccess    ";"  "&" (snd <$> operator ";")  ";"
       expectSuccess    ";;" ""  (snd <$> operator ";;") ";;"
       expectSuccessEof "|"  ""  (snd <$> operator "|")  "|"
-      expectSuccessEof "|"  "&" (snd <$> operator "|")  "|"
+      expectSuccess    "|"  "&" (snd <$> operator "|")  "|"
       expectSuccess    "||" ""  (snd <$> operator "||") "||"
       expectSuccessEof "&"  ""  (snd <$> operator "&")  "&"
-      expectSuccessEof "&"  "|" (snd <$> operator "&")  "&"
+      expectSuccess    "&"  "|" (snd <$> operator "&")  "&"
       expectSuccess    "&&" ""  (snd <$> operator "&&") "&&"
       expectSuccess    "("  ""  (snd <$> operator "(")  "("
       expectSuccess    ")"  ""  (snd <$> operator ")")  ")"
 
     context "parses argument redirection operator" $ do
       expectSuccessEof "<"   ""  (snd <$> operator "<")   "<"
-      expectSuccessEof "<"   "-" (snd <$> operator "<")   "<"
-      expectSuccessEof "<"   "|" (snd <$> operator "<")   "<"
+      expectSuccess    "<"   "-" (snd <$> operator "<")   "<"
+      expectSuccess    "<"   "|" (snd <$> operator "<")   "<"
       expectSuccessEof "<<"  ""  (snd <$> operator "<<")  "<<"
-      expectSuccessEof "<<"  "|" (snd <$> operator "<<")  "<<"
+      expectSuccess    "<<"  "|" (snd <$> operator "<<")  "<<"
       expectSuccess    "<<-" ""  (snd <$> operator "<<-") "<<-"
       expectSuccess    "<>"  ""  (snd <$> operator "<>")  "<>"
       expectSuccess    "<&"  ""  (snd <$> operator "<&")  "<&"
       expectSuccessEof ">"   ""  (snd <$> operator ">")   ">"
-      expectSuccessEof ">"   "-" (snd <$> operator ">")   ">"
+      expectSuccess    ">"   "-" (snd <$> operator ">")   ">"
       expectSuccess    ">>"  ""  (snd <$> operator ">>")  ">>"
       expectSuccess    ">|"  ""  (snd <$> operator ">|")  ">|"
       expectSuccess    ">&"  ""  (snd <$> operator ">&")  ">&"
@@ -138,16 +138,16 @@ spec = do
       expectFailure    "<<-" (operator "<")  Soft UnknownReason 0
       expectFailure    "<<-" (operator "<<") Soft UnknownReason 0
       expectFailure    "<>"  (operator "<<") Soft UnknownReason 0
-      expectFailureEof ">>"  (operator ">")  Soft UnknownReason 0
+      expectFailure    ">>"  (operator ">")  Soft UnknownReason 0
       expectFailure    ">|"  (operator ">")  Soft UnknownReason 0
       expectFailure    ">&"  (operator ">")  Soft UnknownReason 0
       expectFailure    "\\\n>&" (operator ">") Soft UnknownReason 2
 
   describe "ioNumber" $ do
     context "parses digits followed by < or >" $ do
-      expectSuccessEof "1" "<" ioNumber 1
-      expectSuccessEof "20" ">" ioNumber 20
-      expectSuccessEof "123" ">" ioNumber 123
+      expectSuccess "1" "<" ioNumber 1
+      expectSuccess "20" ">" ioNumber 20
+      expectSuccess "123" ">" ioNumber 123
 
     context "rejects non-digits" $ do
       expectFailure "<" ioNumber Soft UnknownReason 0

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -107,17 +107,18 @@ spec = do
 
   describe "aliasableToken" $ do
     let at = runAliasT aliasableToken
+        at' = runAliasT aliasableToken
 
     context "returns unmatched token" $ do
-      expectShow "foo" ";" at "Just foo"
+      expectShow "foo" ";" at' "Just foo"
 
     context "returns quoted token" $ do
-      expectShow "f\\oo" ";" at "Just f\\oo"
-      expectShow "f\"o\"o" "&" at "Just f\"o\"o"
-      expectShow "f'o'o" ")" at "Just f'o'o"
+      expectShow "f\\oo" ";" at' "Just f\\oo"
+      expectShow "f\"o\"o" "&" at' "Just f\"o\"o"
+      expectShow "f'o'o" ")" at' "Just f'o'o"
 
     context "returns non-constant token" $ do
-      expectShow "f${1}o" ";" at "Just f${1}o"
+      expectShow "f${1}o" ";" at' "Just f${1}o"
 
     context "modifies pending input" $ do
       expectSuccessEof defaultAliasName "" (at >> readAll) defaultAliasValue
@@ -302,6 +303,7 @@ spec = do
 
   describe "andOrList" $ do
     let aol = runAliasT $ fill andOrList
+        aol' = runAliasT $ fill andOrList
 
     context "consists of pipelines" $ do
       expectShowEof "foo;" "" aol "Just foo;"
@@ -316,16 +318,16 @@ spec = do
         "Just foo && ! bar || baz&"
 
     context "can end before newline" $ do
-      expectShow "foo" "\n" aol "Just foo;"
-      expectShow "foo && bar" "\n" aol "Just foo && bar;"
+      expectShow "foo" "\n" aol' "Just foo;"
+      expectShow "foo && bar" "\n" aol' "Just foo && bar;"
       context "cannot have newlines before && or ||" $ do
         expectShowEof "foo" "\n&&bar" aol "Just foo;"
         expectShowEof "foo" "\n||bar" aol "Just foo;"
 
     context "can end before operators" $ do
-      expectShow "foo" ";;" aol "Just foo;"
-      expectShow "foo" "("  aol "Just foo;"
-      expectShow "foo" ")"  aol "Just foo;"
+      expectShow "foo" ";;" aol' "Just foo;"
+      expectShow "foo" "("  aol' "Just foo;"
+      expectShow "foo" ")"  aol' "Just foo;"
 
     context "can end at end of input" $ do
       expectShowEof "foo" "" aol "Just foo;"

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -102,8 +102,7 @@ spec = do
       expectShow "a\\\nX" "" (tokenTill (lc (char 'X'))) "a"
 
     context "rejects empty token" $ do
-      expectFailureEof "\\\n)" (tokenTill (lc (char ')')))
-        Soft UnknownReason 0
+      expectFailure "\\\n)" (tokenTill (lc (char ')'))) Soft UnknownReason 0
 
   describe "aliasableToken" $ do
     let at = runAliasT aliasableToken
@@ -264,6 +263,7 @@ spec = do
 
   describe "pipeline" $ do
     let p = runAliasT $ fill pipeline
+        p' = runAliasT $ fill pipeline
 
     context "can start with !" $ do
       expectShowEof "! foo bar " "\n" p "Just ! foo bar"
@@ -274,11 +274,12 @@ spec = do
       expectShowEof "\\\nnew" "" p "Just new"
 
     context "requires command after !" $ do
-      expectFailureEof "!" p Hard (MissingCommandAfter "!") 1
-      expectFailureEof "! ;" p Hard (MissingCommandAfter "!") 2
+      expectFailureEof "!"   p  Hard (MissingCommandAfter "!") 1
+      expectFailure    "! ;" p' Hard (MissingCommandAfter "!") 2
 
   describe "conditionalPipeline" $ do
     let cp = runAliasT $ fill conditionalPipeline
+        cp' = runAliasT $ fill conditionalPipeline
 
     context "can start with && followed by pipeline" $ do
       expectShowEof "&&foo" "" cp "Just && foo"
@@ -293,13 +294,13 @@ spec = do
       expectShowEof "|| \n \n foo" ";" cp "Just || foo"
 
     context "requires pipeline after operator" $ do
-      expectFailureEof "&&"    cp Hard (MissingCommandAfter "&&") 2
-      expectFailureEof "||\n;" cp Hard (MissingCommandAfter "||") 3
+      expectFailureEof "&&"    cp  Hard (MissingCommandAfter "&&") 2
+      expectFailure    "||\n;" cp' Hard (MissingCommandAfter "||") 3
 
     context "must start with operator" $ do
-      expectFailureEof "foo" cp Soft UnknownReason 0
-      expectFailureEof "! bar" cp Soft UnknownReason 0
-      expectFailureEof ";" cp Soft UnknownReason 0
+      expectFailure    "foo"   cp' Soft UnknownReason 0
+      expectFailure    "! bar" cp' Soft UnknownReason 0
+      expectFailureEof ";"     cp  Soft UnknownReason 0
 
   describe "andOrList" $ do
     let aol = runAliasT $ fill andOrList
@@ -357,8 +358,8 @@ spec = do
     context "fails with incomplete line" $ do
       expectFailureEof ";"      completeLine Hard UnknownReason 0
       expectFailureEof "&"      completeLine Hard UnknownReason 0
-      expectFailureEof "foo;&"  completeLine Hard UnknownReason 4
-      expectFailureEof "foo("   completeLine Hard UnknownReason 3
+      expectFailure    "foo;&"  completeLine Hard UnknownReason 4
+      expectFailure    "foo("   completeLine Hard UnknownReason 3
       expectFailureEof "foo& ;" completeLine Hard UnknownReason 5
       expectFailureEof "foo;;"  completeLine Hard UnknownReason 3
 

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -275,7 +275,7 @@ spec = do
 
     context "requires command after !" $ do
       expectFailureEof "!"   p  Hard (MissingCommandAfter "!") 1
-      expectFailure    "! ;" p' Hard (MissingCommandAfter "!") 2
+      expectFailure    "! )" p' Hard (MissingCommandAfter "!") 2
 
   describe "conditionalPipeline" $ do
     let cp = runAliasT $ fill conditionalPipeline
@@ -295,7 +295,7 @@ spec = do
 
     context "requires pipeline after operator" $ do
       expectFailureEof "&&"    cp  Hard (MissingCommandAfter "&&") 2
-      expectFailure    "||\n;" cp' Hard (MissingCommandAfter "||") 3
+      expectFailure    "||\n)" cp' Hard (MissingCommandAfter "||") 3
 
     context "must start with operator" $ do
       expectFailure    "foo"   cp' Soft UnknownReason 0
@@ -321,9 +321,11 @@ spec = do
     context "can end before newline" $ do
       expectShow "foo" "\n" aol' "Just foo;"
       expectShow "foo && bar" "\n" aol' "Just foo && bar;"
+{- These special cases are covered by the case above
       context "cannot have newlines before && or ||" $ do
         expectShowEof "foo" "\n&&bar" aol "Just foo;"
         expectShowEof "foo" "\n||bar" aol "Just foo;"
+-}
 
     context "can end before operators" $ do
       expectShow "foo" ";;" aol' "Just foo;"
@@ -358,7 +360,7 @@ spec = do
     context "fails with incomplete line" $ do
       expectFailureEof ";"      completeLine Hard UnknownReason 0
       expectFailureEof "&"      completeLine Hard UnknownReason 0
-      expectFailure    "foo;&"  completeLine Hard UnknownReason 4
+      expectFailure    "foo;& " completeLine Hard UnknownReason 4
       expectFailure    "foo("   completeLine Hard UnknownReason 3
       expectFailureEof "foo& ;" completeLine Hard UnknownReason 5
       expectFailureEof "foo;;"  completeLine Hard UnknownReason 3

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -123,17 +123,17 @@ spec = do
       expectSuccessEof defaultAliasName "" (at >> readAll) defaultAliasValue
 
     it "returns nothing after substitution" $
-      let e = runTesterWithDummyPositions at defaultAliasName
+      let e = runFullInputTesterWithDummyPositions at defaultAliasName
        in fmap fst e `shouldBe` Right Nothing
 
     it "stops on recursion" $
-      let e = runTesterWithDummyPositions (reparse aliasableToken >> readAll)
-                defaultAliasName
+      let e = runFullInputTesterWithDummyPositions
+                (reparse aliasableToken >> readAll) defaultAliasName
        in fmap fst e `shouldBe` Right "--color"
 
     it "stops on exact recursion" $
-      let e = runTesterWithDummyPositions (reparse aliasableToken >> readAll)
-                recursiveAlias
+      let e = runFullInputTesterWithDummyPositions
+                (reparse aliasableToken >> readAll) recursiveAlias
        in fmap fst e `shouldBe` Right ""
 
   describe "reserved" $ do
@@ -236,7 +236,7 @@ spec = do
       expectFailureEof "" sc Soft UnknownReason 0
 
     it "returns nothing after alias substitution" $
-      let e = runTesterWithDummyPositions sc defaultAliasName
+      let e = runFullInputTesterWithDummyPositions sc defaultAliasName
        in fmap fst e `shouldBe` Right Nothing
 
     context "does not alias-substitute second token" $ do
@@ -369,7 +369,7 @@ spec = do
             (Pipeline (SimpleCommand [] [] [HereDoc _ c] :| _) _) _ _] =
               Just c
           f _ = Nothing
-          p = runTesterWithDummyPositions (f <$> completeLine)
+          p = runFullInputTesterWithDummyPositions (f <$> completeLine)
 
       it "fills empty here document content" $
         fmap fst (p "<<X\nX\n") `shouldBe` Right (Just [])

--- a/hspec-src/Flesh/Language/Parser/TestUtil.hs
+++ b/hspec-src/Flesh/Language/Parser/TestUtil.hs
@@ -136,6 +136,11 @@ runFullInputTesterWithDummyPositions :: FullInputTester a -> String
 runFullInputTesterWithDummyPositions parser s = runFullInputTester parser s'
   where s' = spread (dummyPosition s) s
 
+runOverrunTesterWithDummyPositions :: OverrunTester a -> String ->
+  Maybe (Either Failure (a, PositionedString))
+runOverrunTesterWithDummyPositions parser s = runOverrunTester parser s'
+  where s' = spread (dummyPosition s) s
+
 readAll :: MonadParser m => m String
 readAll = fmap (fmap snd) (many anyChar)
 

--- a/hspec-src/Flesh/Language/Parser/TestUtil.hs
+++ b/hspec-src/Flesh/Language/Parser/TestUtil.hs
@@ -129,14 +129,14 @@ runTesterWithDummyPositions parser s = runTester parser s'
 readAll :: MonadParser m => m String
 readAll = fmap (fmap snd) (many anyChar)
 
--- | @expectSuccessEof consumed lookahead parser result@ runs the given
--- @parser@ for the source code @consumed ++ lookahead@ and tests if the
+-- | @expectSuccessEof consumed unconsumed parser result@ runs the given
+-- @parser@ for the source code @consumed ++ unconsumed@ and tests if the
 -- expected @result@ is returned and if the expected @consumed@ part of the
 -- code is actually consumed.
 expectSuccessEof :: (Eq a, Show a) =>
   String -> String -> Tester a -> a -> SpecWith ()
-expectSuccessEof consumed lookahead parser result =
-  let s = consumed ++ lookahead
+expectSuccessEof consumed unconsumed parser result =
+  let s = consumed ++ unconsumed
       s' = spread (dummyPosition s) s
       e = runTester parser s'
    in context s $ do
@@ -149,10 +149,10 @@ expectSuccessEof consumed lookahead parser result =
 -- | Like 'expectSuccessEof', but tries many arbitrary remainders.
 expectSuccess :: (Eq a, Show a) =>
   String -> String -> Tester a -> a -> SpecWith ()
-expectSuccess consumed lookahead parser result =
-  context (consumed ++ lookahead ++ "...") $
+expectSuccess consumed unconsumed parser result =
+  context (consumed ++ unconsumed ++ "...") $
     prop "returns expected result and state" $ \remainder ->
-      let s = consumed ++ lookahead ++ remainder
+      let s = consumed ++ unconsumed ++ remainder
           s' = spread (dummyPosition s) s
           e = runTester parser s'
        in e === Right (result, dropP (length consumed) s')
@@ -184,13 +184,13 @@ expectPosition input parser expectedPositionIndex =
 -- with the given expected string.
 expectShowEof :: Show a =>
   String -> String -> Tester a -> String -> SpecWith ()
-expectShowEof consumed lookahead parser =
-  expectSuccessEof consumed lookahead (show <$> parser)
+expectShowEof consumed unconsumed parser =
+  expectSuccessEof consumed unconsumed (show <$> parser)
 
 -- | Like 'expectShowEof', but tries many arbitrary remainders.
 expectShow :: Show a => String -> String -> Tester a -> String -> SpecWith ()
-expectShow consumed lookahead parser =
-  expectSuccess consumed lookahead (show <$> parser)
+expectShow consumed unconsumed parser =
+  expectSuccess consumed unconsumed (show <$> parser)
 
 -- | @expectFailureEof input parser severity reason position@ runs the given
 -- @parser@ for the given @input@ and tests if it fails for the expected error

--- a/hspec-src/Flesh/Language/Parser/TestUtil.hs
+++ b/hspec-src/Flesh/Language/Parser/TestUtil.hs
@@ -35,8 +35,6 @@ import Flesh.Language.Parser.Error
 import Flesh.Language.Parser.Input
 import Flesh.Source.Position
 import Test.Hspec
-import Test.Hspec.QuickCheck
-import Test.QuickCheck
 
 newtype Overrun a = Overrun {
   runOverrun :: StateT PositionedString (ExceptT Failure Maybe) a}
@@ -116,12 +114,22 @@ runFullInputTesterAlias :: FullInputTester a
                         -> Either Failure (a, PositionedString)
 runFullInputTesterAlias parser defs ps =
   runIdentity $ runExceptT $ runStateT (runTesterAliasT parser defs) ps
-    
+
+runOverrunTesterAlias :: OverrunTester a
+                      -> Alias.DefinitionSet -> PositionedString
+                      -> Maybe (Either Failure (a, PositionedString))
+runOverrunTesterAlias parser defs ps =
+  runExceptT $ runStateT m ps
+    where m = runOverrun $ runTesterAliasT parser defs
 
 runFullInputTester :: FullInputTester a -> PositionedString
                    -> Either Failure (a, PositionedString)
 runFullInputTester parser =
   runFullInputTesterAlias parser defaultAliasDefinitions
+
+runOverrunTester :: OverrunTester a -> PositionedString
+                 -> Maybe (Either Failure (a, PositionedString))
+runOverrunTester parser = runOverrunTesterAlias parser defaultAliasDefinitions
 
 runFullInputTesterWithDummyPositions :: FullInputTester a -> String
                             -> Either Failure (a, PositionedString)
@@ -134,7 +142,8 @@ readAll = fmap (fmap snd) (many anyChar)
 -- | @expectSuccessEof consumed unconsumed parser result@ runs the given
 -- @parser@ for the source code @consumed ++ unconsumed@ and tests if the
 -- expected @result@ is returned and if the expected @consumed@ part of the
--- code is actually consumed.
+-- code is actually consumed. If the parser tries to read beyond the
+-- @unconsumed@ part, it receives end-of-file.
 expectSuccessEof :: (Eq a, Show a) =>
   String -> String -> FullInputTester a -> a -> SpecWith ()
 expectSuccessEof consumed unconsumed parser result =
@@ -148,20 +157,28 @@ expectSuccessEof consumed unconsumed parser result =
      it "consumes expected part of source code" $
        fmap snd e `shouldBe` Right (dropP (length consumed) s')
 
--- | Like 'expectSuccessEof', but tries many arbitrary remainders.
+-- | @expectSuccess consumed unconsumed parser result@ runs the given @parser@
+-- for the source code @consumed ++ unconsumed@ and tests if the expected
+-- @result@ is returned and if the expected @consumed@ part of the code is
+-- actually consumed. The test fails if the parser tries to look ahead beyond
+-- the @unconsumed@ part.
 expectSuccess :: (Eq a, Show a) =>
-  String -> String -> FullInputTester a -> a -> SpecWith ()
+  String -> String -> OverrunTester a -> a -> SpecWith ()
 expectSuccess consumed unconsumed parser result =
-  context (consumed ++ unconsumed ++ "...") $
-    prop "returns expected result and state" $ \remainder ->
-      let s = consumed ++ unconsumed ++ remainder
-          s' = spread (dummyPosition s) s
-          e = runFullInputTester parser s'
-       in e === Right (result, dropP (length consumed) s')
+  let s = consumed ++ unconsumed
+      s' = spread (dummyPosition s) s
+      e = runOverrunTester parser s'
+   in context s $ do
+     it "returns expected result successfully" $
+       fmap (fmap fst) e `shouldBe` Just (Right result)
+
+     it "consumes expected part of source code" $
+       fmap (fmap snd) e `shouldBe` Just (Right (dropP (length consumed) s'))
 
 -- | @expectPositionEof input parser expectedPositionIndex@ runs the given
 -- @parser@ for the given @input@ and tests if the result is a position at the
--- given index withing the input.
+-- given index withing the input. If the parser tries to read beyond the
+-- @input@, it receives end-of-file.
 expectPositionEof :: String -> FullInputTester Position -> Int -> SpecWith ()
 expectPositionEof input parser expectedPositionIndex =
   let s' = spread (dummyPosition input) input
@@ -171,16 +188,18 @@ expectPositionEof input parser expectedPositionIndex =
      it "returns expected position" $
        fmap fst e `shouldBe` Right expectedPosition
 
--- | Like 'expectPositionEof', but tries many arbitrary remainders.
-expectPosition :: String -> FullInputTester Position -> Int -> SpecWith ()
+-- | @expectPosition input parser expectedPositionIndex@ runs the given
+-- @parser@ for the given @input@ and tests if the result is a position at the
+-- given index withing the input. The test fails if the parser tries to look
+-- ahead beyond the @input@.
+expectPosition :: String -> OverrunTester Position -> Int -> SpecWith ()
 expectPosition input parser expectedPositionIndex =
-  context (input ++ "...") $
-    prop "returns expected position" $ \remainder ->
-      let s = input ++ remainder
-          s' = spread (dummyPosition s) s
-          e = runFullInputTester parser s'
-          expectedPosition = headPosition (dropP expectedPositionIndex s')
-       in fmap fst e === Right expectedPosition
+  let s' = spread (dummyPosition input) input
+      e = runOverrunTester parser s'
+      expectedPosition = headPosition (dropP expectedPositionIndex s')
+   in context input $ do
+     it "returns expected position" $
+       fmap (fmap fst) e `shouldBe` Just (Right expectedPosition)
 
 -- | Like 'expectSuccessEof', but compares string representation of the result
 -- with the given expected string.
@@ -191,7 +210,7 @@ expectShowEof consumed unconsumed parser =
 
 -- | Like 'expectShowEof', but tries many arbitrary remainders.
 expectShow :: Show a
-           => String -> String -> FullInputTester a -> String -> SpecWith ()
+           => String -> String -> OverrunTester a -> String -> SpecWith ()
 expectShow consumed unconsumed parser =
   expectSuccess consumed unconsumed (show <$> parser)
 

--- a/hspec-src/Flesh/Language/Parser/TestUtil.hs
+++ b/hspec-src/Flesh/Language/Parser/TestUtil.hs
@@ -216,7 +216,8 @@ expectShow consumed unconsumed parser =
 
 -- | @expectFailureEof input parser severity reason position@ runs the given
 -- @parser@ for the given @input@ and tests if it fails for the expected error
--- of the given @severity@, @reason@, and @position@.
+-- of the given @severity@, @reason@, and @position@. If the parser tries to
+-- read beyond the @unconsumed@ part, it receives end-of-file.
 --
 -- Type parameter @a@ needs to be 'Show' and 'Eq'. Map to @()@ if you want to
 -- apply to a non-Show or non-Eq @a@.
@@ -229,6 +230,18 @@ expectFailureEof input parser s r expectedPositionIndex =
    in context input $ do
      it "fails" $
        e `shouldBe` Left (s, Error r expectedPosition)
+
+-- | Like 'expectFailureEof', but the test fails if the parser tries to look
+-- ahead beyond the @input@.
+expectFailure :: (Eq a, Show a) =>
+  String -> OverrunTester a -> Severity -> Reason -> Int -> SpecWith ()
+expectFailure input parser s r expectedPositionIndex =
+  let s' = spread (dummyPosition input) input
+      e = runOverrunTester parser s'
+      expectedPosition = headPosition (dropP expectedPositionIndex s')
+   in context input $ do
+     it "fails" $
+       e `shouldBe` Just (Left (s, Error r expectedPosition))
 
 -- | @expectFailureEof'@ is like 'expectFailureEof', but tests the reason by
 -- predicate rather than direct comparison. This is useful when the reason
@@ -245,6 +258,27 @@ expectFailureEof' input parser s r expectedPositionIndex =
          Right e' ->
            it "fails" $ expectationFailure $ show e'
          Left (as, Error ar apos) -> do
+           it "fails with expected severity" $ as `shouldBe` s
+           it "fails with expected reason" $ ar `shouldSatisfy` r
+           it "fails at expected position" $ apos `shouldBe` expectedPosition
+
+-- | @expectFailure'@ is like 'expectFailure', but tests the reason by
+-- predicate rather than direct comparison. This is useful when the reason
+-- cannot be easily constructed.
+expectFailure' :: Show a =>
+  String -> OverrunTester a -> Severity -> (Reason -> Bool) -> Int ->
+    SpecWith ()
+expectFailure' input parser s r expectedPositionIndex =
+  let s' = spread (dummyPosition input) input
+      e = runOverrunTester parser s'
+      expectedPosition = headPosition (dropP expectedPositionIndex s')
+   in context input $
+       case e of
+         Nothing ->
+           it "fails" $ expectationFailure "input overrun"
+         Just (Right e') ->
+           it "fails" $ expectationFailure $ show e'
+         Just (Left (as, Error ar apos)) -> do
            it "fails with expected severity" $ as `shouldBe` s
            it "fails with expected reason" $ ar `shouldSatisfy` r
            it "fails at expected position" $ apos `shouldBe` expectedPosition

--- a/src/Flesh/Language/Parser/Alias.hs
+++ b/src/Flesh/Language/Parser/Alias.hs
@@ -121,6 +121,7 @@ instance MonadParser m => MonadInput (AliasT m) where
   popChar = lift popChar
   lookahead = mapAliasT lookahead
   peekChar = lift peekChar
+  currentPosition = lift currentPosition
   pushChars = lift . pushChars
 
 instance (MonadParser m, MonadError e m) => MonadError e (AliasT m) where

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -255,6 +255,7 @@ instance MonadInput m => MonadInput (ParserT m) where
   popChar = lift popChar
   lookahead = mapParserT lookahead
   peekChar = lift peekChar
+  currentPosition = lift currentPosition
   pushChars = lift <$> pushChars
 
 instance MonadError e m => MonadError e (ParserT m) where

--- a/src/Flesh/Language/Parser/HereDoc.hs
+++ b/src/Flesh/Language/Parser/HereDoc.hs
@@ -154,6 +154,7 @@ instance MonadParser m => MonadInput (AccumT m) where
   popChar = lift popChar
   lookahead = mapAccumT lookahead
   peekChar = lift peekChar
+  currentPosition = lift currentPosition
   pushChars = lift . pushChars
 
 instance MonadParser m => MonadParser (AccumT m)

--- a/src/Flesh/Language/Parser/Input.hs
+++ b/src/Flesh/Language/Parser/Input.hs
@@ -29,7 +29,7 @@ This module defines types and functions for reading input for the syntax
 parser.
 -}
 module Flesh.Language.Parser.Input (
-  MonadInput(..), followedBy, currentPosition) where
+  MonadInput(..), followedBy) where
 
 import Flesh.Source.Position
 import Control.Monad.Except
@@ -67,6 +67,10 @@ class Monad m => MonadInput m where
   -- position. The default implementation is @lookahead popChar@.
   peekChar :: m (Either Position (Positioned Char))
   peekChar = lookahead popChar
+  -- | Returns the current position.
+  -- The default implementation is @either id fst <$> peekChar@.
+  currentPosition :: m Position
+  currentPosition = either id fst <$> peekChar
   -- | Pushes the given characters into the current position. Subsequent reads
   -- must first return the inserted characters and then return to the original
   -- position, continuing to characters that would have been immediately read
@@ -76,10 +80,6 @@ class Monad m => MonadInput m where
 -- | Like 'lookahead', but ignores the result.
 followedBy :: MonadInput m => m a -> m ()
 followedBy = void . lookahead
-
--- | Returns the current position.
-currentPosition :: MonadInput m => m Position
-currentPosition = either id fst <$> peekChar
 
 -- This would result in undecidable instance.
 -- instance (Monad m, MonadState PositionedString m) => MonadInput m where

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -256,12 +256,13 @@ pipeline =
 
 -- | Parses an and-or condition token (@&&@ or @||@).
 andOrCondition :: MonadParser m => m AndOrCondition
-andOrCondition = do
-  (p, o) <- anyOperator <* whites
-  case o of
-    "&&" -> return AndThen
-    "||" -> return OrElse
-    _ -> failureOfPosition p
+andOrCondition = op <* whites
+  where op = do
+          (p, o) <- anyOperator
+          case o of
+            "&&" -> return AndThen
+            "||" -> return OrElse
+            _ -> failureOfPosition p
 
 -- | Parses a conditional pipeline.
 conditionalPipeline :: (MonadParser m, MonadReader Alias.DefinitionSet m)
@@ -281,12 +282,13 @@ conditionalPipeline =
 -- | Parses a separator operator (@;@ or @&@). Returns True and False if the
 -- separator is @&@ and @;@, respectively.
 separatorOp :: MonadParser m => m Bool
-separatorOp = do
-  (p, o) <- anyOperator <* whites
-  case o of
-    ";" -> return False
-    "&" -> return True
-    _ -> failureOfPosition p
+separatorOp = op <* whites
+  where op = do
+          (p, o) <- anyOperator
+          case o of
+            ";" -> return False
+            "&" -> return True
+            _ -> failureOfPosition p
 
 -- | Parses an and-or list (@and_or@) and 'separator'.
 andOrList :: (MonadParser m, MonadReader Alias.DefinitionSet m)

--- a/src/Flesh/Source/Position.hs
+++ b/src/Flesh/Source/Position.hs
@@ -75,7 +75,7 @@ data Situation =
 -- | Source code fragment, typically a single line of code.
 data Fragment = Fragment {
     -- | Source code.
-    code :: !String,
+    code :: String,
     -- | Situation in which the source code occurred.
     situation :: !Situation,
     -- | Line number (starts from 0).

--- a/src/Flesh/Source/Position.hs
+++ b/src/Flesh/Source/Position.hs
@@ -80,7 +80,11 @@ data Fragment = Fragment {
     situation :: !Situation,
     -- | Line number (starts from 0).
     lineNo :: !Int}
-  deriving (Eq, Show)
+  deriving (Show)
+
+-- | Equality of Fragment is compared ignoring their 'code'.
+instance Eq Fragment where
+  a == b = lineNo a == lineNo b && situation a == situation b
 
 -- | Position of a character that occurs in a source code fragment.
 data Position = Position {


### PR DESCRIPTION
This is a rework of #37.

In the current implementation, `currentPosition` peeks the next character that is not actually needed to return the position. Such peek is (mostly implicitly) caused by the `Applicative` and `Monad` instance for `AliasT`. `currentPosition` needs to be redefined so that it can peek the position without reading the next character.

- Redefine `currentPosition`.
  - [x] Define `currentPosition` as MonadInput member.
  - [x] Redefine `currentPosition` so that it does not read the next character from an underlying input source.
- Update tests (See #37).
  - [x] Define a new test parser type for testing input overrun.
  - [x] Reimplement test utilities using the new two tester types.
  - [x] Add/modify test cases to ensure the parser does not request any input more than needed.
    - Fix `andOrList` overrun.
    - Cherry-pick fb97e141d63b23ebc2960f013127fcd2dce86780.
  - [x] Consider merging common code for the two tester types.
- [x] Ignore `code` in `Position` comparison.
