### PR TITLE
Parse grouping syntax

### DIFF
--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -29,6 +29,7 @@ import Flesh.Language.Parser.HereDoc
 import Flesh.Language.Parser.Lex
 import Flesh.Language.Parser.Syntax
 import Flesh.Language.Parser.TestUtil
+import qualified Flesh.Source.Position as P
 import Test.Hspec
 
 spec :: Spec
@@ -134,6 +135,48 @@ spec = do
     it "stops on exact recursion" $
       let e = runFullInputTesterWithDummyPositions
                 (reparse aliasableToken >> readAll) recursiveAlias
+       in fmap fst e `shouldBe` Right ""
+
+  describe "reservedOrAliasOrToken" $ do
+    let rat = runAliasT reservedOrAliasOrToken
+        rat' = runAliasT reservedOrAliasOrToken
+
+    context "returns unmatched token" $ do
+      expectShow "foo" ";" rat' "Just (Right foo)"
+
+    context "returns quoted token" $ do
+      expectShow "f\\oo" ";" rat' "Just (Right f\\oo)"
+      expectShow "f\"o\"o" "&" rat' "Just (Right f\"o\"o)"
+      expectShow "f'o'o" ")" rat' "Just (Right f'o'o)"
+
+    context "returns non-constant token" $ do
+      expectShow "f${1}o" ";" rat' "Just (Right f${1}o)"
+
+    context "returns reserved word" $ do
+      expectShow "!" ";" rat' "Just (Left \"!\")"
+      expectShowEof reservedWordAliasName "" rat "Just (Left \"while\")"
+
+    it "doesn't perform alias substitution on reserved words" $
+      let e = runFullInputTesterAlias rat reservedWordAliasDefinitions s
+          s = P.spread (P.dummyPosition s') s'
+          s' = reservedWordAliasName
+       in fmap (show . fst) e `shouldBe` Right "Just (Left \"while\")"
+
+    context "modifies pending input on alias subsitution" $ do
+      expectSuccessEof defaultAliasName "" (rat >> readAll) defaultAliasValue
+
+    it "returns nothing after substitution" $
+      let e = runFullInputTesterWithDummyPositions rat defaultAliasName
+       in fmap fst e `shouldBe` Right Nothing
+
+    it "stops alias substitution on recursion" $
+      let e = runFullInputTesterWithDummyPositions
+                (reparse reservedOrAliasOrToken >> readAll) defaultAliasName
+       in fmap fst e `shouldBe` Right "--color"
+
+    it "stops alias substitution on exact recursion" $
+      let e = runFullInputTesterWithDummyPositions
+                (reparse reservedOrAliasOrToken >> readAll) recursiveAlias
        in fmap fst e `shouldBe` Right ""
 
   describe "reserved" $ do

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -179,20 +179,20 @@ spec = do
                 (reparse reservedOrAliasOrToken >> readAll) recursiveAlias
        in fmap fst e `shouldBe` Right ""
 
-  describe "reserved" $ do
+  describe "literal" $ do
     context "returns matching unquoted token" $ do
-      expectShowEof "! " "" (reserved (T.pack "!")) "!"
-      expectShow    "i\\\nf" "\n" (reserved (T.pack "if")) "if"
-      expectShowEof "foo" "" (reserved (T.pack "foo")) "foo"
+      expectShowEof "! " "" (literal (T.pack "!")) "!"
+      expectShow    "i\\\nf" "\n" (literal (T.pack "if")) "if"
+      expectShowEof "foo" "" (literal (T.pack "foo")) "foo"
 
     context "fails on unmatching unquoted token" $ do
-      expectFailureEof "a" (reserved (T.pack "!")) Soft UnknownReason 0
-      expectFailureEof "a" (reserved (T.pack "aa")) Soft UnknownReason 0
-      expectFailureEof "aa" (reserved (T.pack "a")) Soft UnknownReason 0
+      expectFailureEof "a" (literal (T.pack "!")) Soft UnknownReason 0
+      expectFailureEof "a" (literal (T.pack "aa")) Soft UnknownReason 0
+      expectFailureEof "aa" (literal (T.pack "a")) Soft UnknownReason 0
 
     context "fails on quoted token" $ do
-      expectFailureEof "\\if" (reserved (T.pack "if")) Soft UnknownReason 0
-      expectFailureEof "i\\f" (reserved (T.pack "if")) Soft UnknownReason 0
+      expectFailureEof "\\if" (literal (T.pack "if")) Soft UnknownReason 0
+      expectFailureEof "i\\f" (literal (T.pack "if")) Soft UnknownReason 0
 
   describe "redirect" $ do
     let yieldDummyContent = HereDocT $

--- a/hspec-src/Flesh/Language/Parser/TestUtil.hs
+++ b/hspec-src/Flesh/Language/Parser/TestUtil.hs
@@ -96,6 +96,12 @@ defaultAliasValue = defaultAliasName ++ " --color"
 recursiveAlias :: String
 recursiveAlias = "rec"
 
+reservedWordAliasName :: String
+reservedWordAliasName = "while"
+
+reservedWordAliasValue :: String
+reservedWordAliasValue = ";;"
+
 defaultAliasDefinitions :: Alias.DefinitionSet
 defaultAliasDefinitions =
   M.insert n (Alias.definition n v p) $
@@ -105,6 +111,12 @@ defaultAliasDefinitions =
             p = dummyPosition "alias ls='ls --color'"
             r = T.pack recursiveAlias
             pr = dummyPosition "alias rec=rec"
+
+reservedWordAliasDefinitions :: Alias.DefinitionSet
+reservedWordAliasDefinitions = M.singleton n (Alias.definition n v p)
+  where n = T.pack reservedWordAliasName
+        v = T.pack reservedWordAliasValue
+        p = dummyPosition "alias while=';;'"
 
 runTesterAliasT :: TesterT m a -> Alias.DefinitionSet -> m a
 runTesterAliasT parser defs = runReaderT (runParserT parser) defs

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -194,7 +194,7 @@ notFollowedBy m = do
   join $ catchError m' (const $ return $ return ())
 
 -- | @some' a@ is like @some a@, but returns a NonEmpty list.
-some' :: MonadParser m => m a -> m (NonEmpty a)
+some' :: Alternative m => m a -> m (NonEmpty a)
 some' a = (:|) <$> a <*> many a
 
 -- | Monad wrapper that instantiates 'MonadParser' from 'MonadInput' and

--- a/src/Flesh/Language/Parser/Lex.hs
+++ b/src/Flesh/Language/Parser/Lex.hs
@@ -28,11 +28,13 @@ shell language.
 module Flesh.Language.Parser.Lex (
   lineContinuation, lc, blank, digit, comment, whites, operatorStarter,
   endOfToken, anyOperator, operator, operatorToken, redirectOperatorToken,
-  ioNumber) where
+  ioNumber, isReserved) where
 
 import Control.Applicative
 import Data.Char
 import qualified Data.List.NonEmpty as NE
+import qualified Data.Set as S
+import qualified Data.Text as T
 import Flesh.Source.Position
 import Flesh.Language.Parser.Char
 import Flesh.Language.Parser.Error
@@ -144,5 +146,39 @@ ioNumber = do
       followedBy $ lc $ oneOfChars "<>"
       return n
     _ -> failureOfPosition $ fst (NE.head ds)
+
+-- | Reserved word text constant.
+reservedBang, reservedCase, reservedDo, reservedDone, reservedElif,
+  reservedElse, reservedEsac, reservedFi, reservedFor, reservedFunction,
+  reservedIf, reservedIn, reservedThen, reservedUntil, reservedWhile,
+  reservedOpenBrace, reservedCloseBrace :: T.Text
+reservedBang       = T.pack "!"
+reservedCase       = T.pack "case"
+reservedDo         = T.pack "do"
+reservedDone       = T.pack "done"
+reservedElif       = T.pack "elif"
+reservedElse       = T.pack "else"
+reservedEsac       = T.pack "esac"
+reservedFi         = T.pack "fi"
+reservedFor        = T.pack "for"
+reservedFunction   = T.pack "function"
+reservedIf         = T.pack "if"
+reservedIn         = T.pack "in"
+reservedThen       = T.pack "then"
+reservedUntil      = T.pack "until"
+reservedWhile      = T.pack "while"
+reservedOpenBrace  = T.pack "{"
+reservedCloseBrace = T.pack "}"
+
+-- | Set of all the reserved words.
+reservedWords :: S.Set T.Text
+reservedWords = S.fromList [reservedBang, reservedCase, reservedDo,
+  reservedDone, reservedElif, reservedElse, reservedEsac, reservedFi,
+  reservedFor, reservedFunction, reservedIf, reservedIn, reservedThen,
+  reservedUntil, reservedWhile, reservedOpenBrace, reservedCloseBrace]
+
+-- | Tests if the argument text is a reserved word token.
+isReserved :: T.Text -> Bool
+isReserved t = S.member t reservedWords
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Parser/Lex.hs
+++ b/src/Flesh/Language/Parser/Lex.hs
@@ -28,7 +28,12 @@ shell language.
 module Flesh.Language.Parser.Lex (
   lineContinuation, lc, blank, digit, comment, whites, operatorStarter,
   endOfToken, anyOperator, operator, operatorToken, redirectOperatorToken,
-  ioNumber, isReserved) where
+  ioNumber,
+  -- * Reserved words
+  reservedBang, reservedCase, reservedDo, reservedDone, reservedElif,
+  reservedElse, reservedEsac, reservedFi, reservedFor, reservedFunction,
+  reservedIf, reservedIn, reservedThen, reservedUntil, reservedWhile,
+  reservedOpenBrace, reservedCloseBrace, isReserved) where
 
 import Control.Applicative
 import Data.Char

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -31,7 +31,8 @@ module Flesh.Language.Parser.Syntax (
   HereDocAliasT, sequenceAliasHereDocT,
   -- * Tokens
   backslashed, doubleQuoteUnit, doubleQuote, singleQuote, wordUnit, tokenTill,
-  normalToken, reservedOrToken, aliasableToken, reserved,
+  normalToken, reservedOrToken, aliasableToken, reservedOrAliasOrToken,
+  reserved,
   -- * Syntax
   redirect, hereDocContent, newlineHD, whitesHD, linebreak,
   simpleCommand, command, pipeSequence, pipeline, conditionalPipeline,
@@ -148,6 +149,28 @@ aliasableToken = AliasT $ do
    in fmap inv $ runMaybeT $ tt >>= substituteAlias pos
    -- TODO substitute the next token if the current substitute ends with a
    -- blank.
+
+-- | Parses a normal non-empty token followed by optional whitespaces.
+-- Reserved words are returned in Left as by 'reservedOrToken'.
+-- Non-reserved words are subject to alias substitution.
+reservedOrAliasOrToken :: (MonadParser m, MonadReader Alias.DefinitionSet m)
+                       => AliasT m (Either T.Text Token)
+reservedOrAliasOrToken = AliasT $ do
+  textOrToken <- reservedOrToken <$> normalToken
+  case textOrToken of
+    Left _ -> -- reserved words are not subject to alias substitution
+      return $ Just textOrToken
+    Right t -> do
+      r <- runMaybeT $ do
+        tt <- MaybeT $ return $ tokenText t
+        let pos = fst $ NE.head $ tokenUnits t
+        substituteAlias pos tt
+      case r of
+        Nothing -> -- no alias substitution performed
+          return $ Just textOrToken
+        Just () -> -- alias substitution performed!
+          return $ Nothing
+-- TODO substitute the next token if the current substitute ends with a blank.
 
 -- | Parses an unquoted token as the given reserved word.
 reserved :: MonadParser m => T.Text -> m Token

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -31,7 +31,7 @@ module Flesh.Language.Parser.Syntax (
   HereDocAliasT, sequenceAliasHereDocT,
   -- * Tokens
   backslashed, doubleQuoteUnit, doubleQuote, singleQuote, wordUnit, tokenTill,
-  normalToken, aliasableToken, reserved,
+  normalToken, reservedOrToken, aliasableToken, reserved,
   -- * Syntax
   redirect, hereDocContent, newlineHD, whitesHD, linebreak,
   simpleCommand, command, pipeSequence, pipeline, conditionalPipeline,
@@ -126,6 +126,14 @@ tokenTill a = notFollowedBy a >> (require $ Token <$> wordUnit `someTill` a)
 -- whitespaces after the token.
 normalToken :: MonadParser m => m Token
 normalToken = tokenTill endOfToken <* whites
+
+-- | Returns the token text in Left if the argument word 'isReserved',
+-- otherwise the argument itself in Right.
+reservedOrToken :: Token -> Either T.Text Token
+reservedOrToken t = maybe (Right t) Left $ do
+  t' <- tokenText t
+  guard $ isReserved t'
+  return t'
 
 -- | Like 'normalToken', but tries to perform alias substitution on the
 -- result.

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -32,7 +32,7 @@ module Flesh.Language.Parser.Syntax (
   -- * Tokens
   backslashed, doubleQuoteUnit, doubleQuote, singleQuote, wordUnit, tokenTill,
   normalToken, reservedOrToken, aliasableToken, reservedOrAliasOrToken,
-  reserved,
+  literal,
   -- * Syntax
   redirect, hereDocContent, newlineHD, whitesHD, linebreak,
   simpleCommand, command, pipeSequence, pipeline, conditionalPipeline,
@@ -172,9 +172,9 @@ reservedOrAliasOrToken = AliasT $ do
           return $ Nothing
 -- TODO substitute the next token if the current substitute ends with a blank.
 
--- | Parses an unquoted token as the given reserved word.
-reserved :: MonadParser m => T.Text -> m Token
-reserved w = normalToken `satisfying` (\t -> tokenText t == Just w)
+-- | Parses an unquoted token that matches the given text.
+literal :: MonadParser m => T.Text -> m Token
+literal w = normalToken `satisfying` (\t -> tokenText t == Just w)
 
 -- | Parses a redirection operator (@io_redirect@) and returns the raw result.
 -- Skips trailing whitespaces.
@@ -215,9 +215,9 @@ hereDocTab :: MonadParser m => Bool -> m ()
 hereDocTab tabbed = when tabbed $ void $ many $ char '\t'
 
 hereDocLine :: MonadParser m => Bool -> Bool -> m [Positioned DoubleQuoteUnit]
-hereDocLine tabbed literal = do
+hereDocLine tabbed isLiteral = do
   hereDocTab tabbed
-  fmap NE.toList $ if literal
+  fmap NE.toList $ if isLiteral
      then fmap (fmap Char) anyChar `manyTo` nl
      else doubleQuoteUnit' (oneOfChars "\\$`") `manyTo` lc nl
        where nl = fmap (fmap Char) (char '\n')
@@ -293,7 +293,7 @@ pipeSequence = (:|) <$> command <*> many trailer
 pipeline :: (MonadParser m, MonadReader Alias.DefinitionSet m)
          => HereDocAliasT m Pipeline
 pipeline =
-  lift (reserved reservedBang) *> req (make True <$> pipeSequence) <|>
+  lift (literal reservedBang) *> req (make True <$> pipeSequence) <|>
   make False <$> pipeSequence
     where req = setReasonHD (MissingCommandAfter "!") . requireHD
           make = flip Pipeline

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -36,7 +36,7 @@ module Flesh.Language.Parser.Syntax (
   -- * Syntax
   redirect, hereDocContent, newlineHD, whitesHD, linebreak,
   simpleCommand, command, pipeSequence, pipeline, conditionalPipeline,
-  andOrList, completeLine) where
+  andOrList, compoundList, completeLine) where
 
 import Control.Applicative
 import Control.Monad.Reader
@@ -339,6 +339,12 @@ andOrList :: (MonadParser m, MonadReader Alias.DefinitionSet m)
           => HereDocAliasT m AndOrList
 andOrList = AndOrList <$> pipeline <*> many conditionalPipeline <*> sep
   where sep = lift $ separatorOp <|> return False
+
+-- | Parses a sequence of one or more and-or lists surrounded by optional
+-- linebreaks.
+compoundList :: (MonadParser m, MonadReader Alias.DefinitionSet m)
+             => HereDocAliasT m (NonEmpty AndOrList)
+compoundList = linebreak *> some' (andOrList <* linebreak)
 
 completeLineBody :: (MonadParser m, MonadReader Alias.DefinitionSet m)
                  => HereDocAliasT m [AndOrList]

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -293,7 +293,7 @@ pipeSequence = (:|) <$> command <*> many trailer
 pipeline :: (MonadParser m, MonadReader Alias.DefinitionSet m)
          => HereDocAliasT m Pipeline
 pipeline =
-  lift (reserved (T.pack "!")) *> req (make True <$> pipeSequence) <|>
+  lift (reserved reservedBang) *> req (make True <$> pipeSequence) <|>
   make False <$> pipeSequence
     where req = setReasonHD (MissingCommandAfter "!") . requireHD
           make = flip Pipeline

--- a/src/Flesh/Language/Syntax.hs
+++ b/src/Flesh/Language/Syntax.hs
@@ -34,8 +34,8 @@ module Flesh.Language.Syntax (
   -- * Redirections
   HereDocOp(..), Redirection(..), fd,
   -- * Syntax
-  Command(..), Pipeline(..), AndOrCondition(..), ConditionalPipeline(..),
-  AndOrList(..)) where
+  CompoundCommand(..), Command(..), Pipeline(..), AndOrCondition(..),
+  ConditionalPipeline(..), AndOrList(..), showSeparatedList) where
 
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NE
@@ -197,11 +197,23 @@ fd :: Redirection -> Natural
 fd (FileRedirection fd') = fd'
 fd (HereDoc (HereDocOp _ fd' _ _) _) = fd'
 
+-- | Commands that can contain other commands.
+data CompoundCommand =
+  -- | one or more and-or lists.
+  Grouping (NonEmpty AndOrList)
+  -- TODO other compound commands
+  deriving (Eq)
+
+instance Show CompoundCommand where
+  showsPrec _ (Grouping ls) =
+    showString "{ " . showSeparatedList (NE.toList ls) . showString " }"
+
 -- | Element of pipelines.
 data Command =
   -- | Simple command.
   SimpleCommand [Token] [P.Positioned Assignment] [Redirection]
-  -- FIXME Compound commands
+  -- | Compound commands
+  | CompoundCommand CompoundCommand
   -- | Function definition.
   | FunctionDefinition -- FIXME
   deriving (Eq)
@@ -216,6 +228,7 @@ instance Show Command where
   showsPrec n (SimpleCommand ts as rs) =
     showList as' . showSpace . showsPrec n (SimpleCommand ts [] rs)
     where as' = snd <$> as
+  showsPrec n (CompoundCommand cc) = showsPrec n cc
   showsPrec _ FunctionDefinition = id -- FIXME
 
 -- | Element of and-or lists. Optionally negated sequence of one or more
@@ -271,5 +284,10 @@ instance Show AndOrList where
   showList [] = id
   showList [l] = shows l
   showList (l:ls) = showsPrec 1 l . showSpace . showList ls
+
+showSeparatedList :: [AndOrList] -> ShowS
+showSeparatedList [] = id
+showSeparatedList [l] = showsPrec 1 l
+showSeparatedList (l:ls) = showsPrec 1 l . showSpace . showSeparatedList ls
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Syntax/Print.hs
+++ b/src/Flesh/Language/Syntax/Print.hs
@@ -35,6 +35,7 @@ module Flesh.Language.Syntax.Print (
 
 import Control.Monad.State.Strict
 import Control.Monad.Writer.Lazy
+import Data.Foldable
 import Data.List.NonEmpty (NonEmpty(..))
 import Flesh.Language.Syntax
 
@@ -116,6 +117,12 @@ instance ListPrintable Redirection where
             showSpace'
             prints r'
 
+instance Printable CompoundCommand where
+  prints (Grouping ls) = do
+    tell' $ showString "{ "
+    printList (toList ls)
+    tell' $ showString " }"
+
 instance Printable Command where
   prints (SimpleCommand [] [] []) = return ()
   prints c@(SimpleCommand _ _ []) = tell' $ shows c
@@ -124,6 +131,7 @@ instance Printable Command where
     prints (SimpleCommand ts as [])
     showSpace'
     printList rs
+  prints (CompoundCommand cc) = prints cc
   prints FunctionDefinition = undefined -- TODO
 
 instance Printable Pipeline where


### PR DESCRIPTION
- [x] Define grouping syntax.
- [x] Print grouping syntax.
- Parse grouping syntax.
  - [x] Parse any reserved word.
  - [ ] In simple command parser, examine the command name token for a reserved word and alias.
  - [ ] Parse grouping syntax.