### PR TITLE
Parse grouping syntax

### DIFF
--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -268,27 +268,6 @@ spec = do
     context "parses pending here doc contents after newline" $ return ()
     -- This property is tested in test cases for other properties.
 
-  describe "simpleCommand" $ do
-    let sc = runAliasT $ fill simpleCommand
-        sc' = runAliasT $ fill simpleCommand
-
-    context "is some tokens" $ do
-      expectShowEof "foo" "" sc "Just foo"
-      expectShowEof "foo bar" ";" sc "Just foo bar"
-      expectShow    "foo  bar\tbaz #X" "\n" sc' "Just foo bar baz"
-
-    context "rejects empty command" $ do
-      expectFailureEof ""   sc  Soft UnknownReason 0
-      expectFailure    "\n" sc' Soft UnknownReason 0
-
-    it "returns nothing after alias substitution" $
-      let e = runFullInputTesterWithDummyPositions sc defaultAliasName
-       in fmap fst e `shouldBe` Right Nothing
-
-    context "does not alias-substitute second token" $ do
-      expectShowEof ("foo " ++ defaultAliasName) "" sc $
-        "Just foo " ++ defaultAliasName
-
   describe "groupingTail" $ do
     let p = P.dummyPosition "X"
         g = snd <$> fill (groupingTail p)

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -383,6 +383,39 @@ spec = do
       expectShowEof "foo" "" aol "Just foo;"
       expectShowEof "foo && bar" "" aol "Just foo && bar;"
 
+  describe "compoundList" $ do
+    let cl = runAliasT $ fill $ NE.toList <$> compoundList
+        cl' = runAliasT $ fill $ NE.toList <$> compoundList
+
+    context "is not empty" $ do
+      expectShow "foo" ";;" cl' "Just foo"
+      expectFailure    ";;" cl' Soft UnknownReason 0
+      expectFailureEof ""   cl  Soft UnknownReason 0
+      expectFailureEof "  " cl  Soft UnknownReason 0
+
+    context "is some and-or lists" $ do
+      expectShowEof "foo; bar"       "" cl "Just foo; bar"
+      expectShowEof "foo; bar& baz;" "" cl "Just foo; bar& baz"
+
+    context "spans multiple lines" $ do
+      expectShowEof "foo\nbar"                 "" cl "Just foo; bar"
+      expectShowEof "foo&\nbar"                "" cl "Just foo& bar"
+      expectShowEof "foo #X\n #comment\n\tbar" "" cl "Just foo; bar"
+      expectShowEof "a;b\nc&d"                 "" cl "Just a; b; c& d"
+
+    context "can have preceding newlines and whites" $ do
+      expectShowEof "\nfoo"              "" cl "Just foo"
+      expectShowEof "\n \tfoo"           "" cl "Just foo"
+      expectShowEof "\n \t#comment\nfoo" "" cl "Just foo"
+      expectShowEof "\n\n\nfoo"          "" cl "Just foo"
+
+    context "can have trailing newlines and whites" $ do
+      expectShowEof "foo\n"              ""   cl  "Just foo"
+      expectShow    "foo\n"              ";;" cl' "Just foo"
+      expectShowEof "foo\n\t "           ""   cl  "Just foo"
+      expectShowEof "foo\n\t #comment\n" ""   cl  "Just foo"
+      expectShow    "foo\n\n\n"          ";;" cl' "Just foo"
+
   describe "completeLine" $ do
     context "can be empty" $ do
       expectShow "\n" "" completeLine ""

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -180,20 +180,20 @@ spec = do
                 (reparse reservedOrAliasOrToken >> readAll) recursiveAlias
        in fmap fst e `shouldBe` Right ""
 
-  describe "reserved" $ do
+  describe "literal" $ do
     context "returns matching unquoted token" $ do
-      expectShowEof "! " "" (reserved (T.pack "!")) "!"
-      expectShow    "i\\\nf" "\n" (reserved (T.pack "if")) "if"
-      expectShowEof "foo" "" (reserved (T.pack "foo")) "foo"
+      expectShowEof "! " "" (literal (T.pack "!")) "!"
+      expectShow    "i\\\nf" "\n" (literal (T.pack "if")) "if"
+      expectShowEof "foo" "" (literal (T.pack "foo")) "foo"
 
     context "fails on unmatching unquoted token" $ do
-      expectFailureEof "a" (reserved (T.pack "!")) Soft UnknownReason 0
-      expectFailureEof "a" (reserved (T.pack "aa")) Soft UnknownReason 0
-      expectFailureEof "aa" (reserved (T.pack "a")) Soft UnknownReason 0
+      expectFailureEof "a" (literal (T.pack "!")) Soft UnknownReason 0
+      expectFailureEof "a" (literal (T.pack "aa")) Soft UnknownReason 0
+      expectFailureEof "aa" (literal (T.pack "a")) Soft UnknownReason 0
 
     context "fails on quoted token" $ do
-      expectFailureEof "\\if" (reserved (T.pack "if")) Soft UnknownReason 0
-      expectFailureEof "i\\f" (reserved (T.pack "if")) Soft UnknownReason 0
+      expectFailureEof "\\if" (literal (T.pack "if")) Soft UnknownReason 0
+      expectFailureEof "i\\f" (literal (T.pack "if")) Soft UnknownReason 0
 
   describe "redirect" $ do
     let yieldDummyContent = HereDocT $

--- a/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/SyntaxSpec.hs
@@ -105,38 +105,6 @@ spec = do
     context "rejects empty token" $ do
       expectFailure "\\\n)" (tokenTill (lc (char ')'))) Soft UnknownReason 0
 
-  describe "aliasableToken" $ do
-    let at = runAliasT aliasableToken
-        at' = runAliasT aliasableToken
-
-    context "returns unmatched token" $ do
-      expectShow "foo" ";" at' "Just foo"
-
-    context "returns quoted token" $ do
-      expectShow "f\\oo" ";" at' "Just f\\oo"
-      expectShow "f\"o\"o" "&" at' "Just f\"o\"o"
-      expectShow "f'o'o" ")" at' "Just f'o'o"
-
-    context "returns non-constant token" $ do
-      expectShow "f${1}o" ";" at' "Just f${1}o"
-
-    context "modifies pending input" $ do
-      expectSuccessEof defaultAliasName "" (at >> readAll) defaultAliasValue
-
-    it "returns nothing after substitution" $
-      let e = runFullInputTesterWithDummyPositions at defaultAliasName
-       in fmap fst e `shouldBe` Right Nothing
-
-    it "stops on recursion" $
-      let e = runFullInputTesterWithDummyPositions
-                (reparse aliasableToken >> readAll) defaultAliasName
-       in fmap fst e `shouldBe` Right "--color"
-
-    it "stops on exact recursion" $
-      let e = runFullInputTesterWithDummyPositions
-                (reparse aliasableToken >> readAll) recursiveAlias
-       in fmap fst e `shouldBe` Right ""
-
   describe "reservedOrAliasOrToken" $ do
     let ignorePosition = either (Left . snd) Right
         rat = runAliasT $ ignorePosition <$> reservedOrAliasOrToken

--- a/hspec-src/Flesh/Language/Parser/TestUtil.hs
+++ b/hspec-src/Flesh/Language/Parser/TestUtil.hs
@@ -96,6 +96,12 @@ defaultAliasValue = defaultAliasName ++ " --color"
 recursiveAlias :: String
 recursiveAlias = "rec"
 
+reservedWordAliasName :: String
+reservedWordAliasName = "while"
+
+reservedWordAliasValue :: String
+reservedWordAliasValue = ";;"
+
 defaultAliasDefinitions :: Alias.DefinitionSet
 defaultAliasDefinitions =
   M.insert n (Alias.definition n v p) $
@@ -105,6 +111,12 @@ defaultAliasDefinitions =
             p = dummyPosition "alias ls='ls --color'"
             r = T.pack recursiveAlias
             pr = dummyPosition "alias rec=rec"
+
+reservedWordAliasDefinitions :: Alias.DefinitionSet
+reservedWordAliasDefinitions = M.singleton n (Alias.definition n v p)
+  where n = T.pack reservedWordAliasName
+        v = T.pack reservedWordAliasValue
+        p = dummyPosition "alias while=';;'"
 
 runTesterAliasT :: TesterT m a -> Alias.DefinitionSet -> m a
 runTesterAliasT parser defs = runReaderT (runParserT parser) defs

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -194,7 +194,7 @@ notFollowedBy m = do
   join $ catchError m' (const $ return $ return ())
 
 -- | @some' a@ is like @some a@, but returns a NonEmpty list.
-some' :: MonadParser m => m a -> m (NonEmpty a)
+some' :: Alternative m => m a -> m (NonEmpty a)
 some' a = (:|) <$> a <*> many a
 
 -- | Monad wrapper that instantiates 'MonadParser' from 'MonadInput' and

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -59,6 +59,7 @@ data Reason =
   | UnclosedHereDocContent HereDocOp
   | MissingHereDocContents (NonEmpty HereDocOp)
   | MissingCommandAfter String
+  | UnclosedGrouping P.Position -- ^ with position of the open brace
   deriving (Eq, Show)
 
 -- | Parse error description.

--- a/src/Flesh/Language/Parser/Lex.hs
+++ b/src/Flesh/Language/Parser/Lex.hs
@@ -28,11 +28,18 @@ shell language.
 module Flesh.Language.Parser.Lex (
   lineContinuation, lc, blank, digit, comment, whites, operatorStarter,
   endOfToken, anyOperator, operator, operatorToken, redirectOperatorToken,
-  ioNumber) where
+  ioNumber,
+  -- * Reserved words
+  reservedBang, reservedCase, reservedDo, reservedDone, reservedElif,
+  reservedElse, reservedEsac, reservedFi, reservedFor, reservedFunction,
+  reservedIf, reservedIn, reservedThen, reservedUntil, reservedWhile,
+  reservedOpenBrace, reservedCloseBrace, isReserved) where
 
 import Control.Applicative
 import Data.Char
 import qualified Data.List.NonEmpty as NE
+import qualified Data.Set as S
+import qualified Data.Text as T
 import Flesh.Source.Position
 import Flesh.Language.Parser.Char
 import Flesh.Language.Parser.Error
@@ -144,5 +151,39 @@ ioNumber = do
       followedBy $ lc $ oneOfChars "<>"
       return n
     _ -> failureOfPosition $ fst (NE.head ds)
+
+-- | Reserved word text constant.
+reservedBang, reservedCase, reservedDo, reservedDone, reservedElif,
+  reservedElse, reservedEsac, reservedFi, reservedFor, reservedFunction,
+  reservedIf, reservedIn, reservedThen, reservedUntil, reservedWhile,
+  reservedOpenBrace, reservedCloseBrace :: T.Text
+reservedBang       = T.pack "!"
+reservedCase       = T.pack "case"
+reservedDo         = T.pack "do"
+reservedDone       = T.pack "done"
+reservedElif       = T.pack "elif"
+reservedElse       = T.pack "else"
+reservedEsac       = T.pack "esac"
+reservedFi         = T.pack "fi"
+reservedFor        = T.pack "for"
+reservedFunction   = T.pack "function"
+reservedIf         = T.pack "if"
+reservedIn         = T.pack "in"
+reservedThen       = T.pack "then"
+reservedUntil      = T.pack "until"
+reservedWhile      = T.pack "while"
+reservedOpenBrace  = T.pack "{"
+reservedCloseBrace = T.pack "}"
+
+-- | Set of all the reserved words.
+reservedWords :: S.Set T.Text
+reservedWords = S.fromList [reservedBang, reservedCase, reservedDo,
+  reservedDone, reservedElif, reservedElse, reservedEsac, reservedFi,
+  reservedFor, reservedFunction, reservedIf, reservedIn, reservedThen,
+  reservedUntil, reservedWhile, reservedOpenBrace, reservedCloseBrace]
+
+-- | Tests if the argument text is a reserved word token.
+isReserved :: T.Text -> Bool
+isReserved t = S.member t reservedWords
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -307,6 +307,20 @@ groupingTail p = f <$> body <* closeBrace
         closeBrace = lift $ require $ setReason (UnclosedGrouping p) $
           literal reservedCloseBrace
 
+-- | Parses a compound command except the first token that determines the type
+-- of the compound command.
+--
+-- The first token is not parsed by this parser. It must have been parsed by
+-- another parser and must be passed as the argument. This parser fails if the
+-- first token does not start a compound command.
+compoundCommandTail :: (MonadParser m, MonadReader Alias.DefinitionSet m)
+                    => Positioned T.Text
+                    -> HereDocT m (Positioned CompoundCommand)
+compoundCommandTail (p, t)
+  | t == reservedOpenBrace = requireHD $ groupingTail p
+  | otherwise = lift $ failureOfPosition p
+  -- TODO if, while, until, for, case
+
 -- | Parses a command.
 command :: (MonadParser m, MonadReader Alias.DefinitionSet m)
         => HereDocAliasT m Command

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -249,7 +249,7 @@ pipeSequence = (:|) <$> command <*> many trailer
 pipeline :: (MonadParser m, MonadReader Alias.DefinitionSet m)
          => HereDocAliasT m Pipeline
 pipeline =
-  lift (reserved (T.pack "!")) *> req (make True <$> pipeSequence) <|>
+  lift (reserved reservedBang) *> req (make True <$> pipeSequence) <|>
   make False <$> pipeSequence
     where req = setReasonHD (MissingCommandAfter "!") . requireHD
           make = flip Pipeline

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -36,7 +36,7 @@ module Flesh.Language.Parser.Syntax (
   -- * Syntax
   redirect, hereDocContent, newlineHD, whitesHD, linebreak,
   simpleCommand, command, pipeSequence, pipeline, conditionalPipeline,
-  andOrList, completeLine) where
+  andOrList, compoundList, completeLine) where
 
 import Control.Applicative
 import Control.Monad.Reader
@@ -327,6 +327,12 @@ andOrList :: (MonadParser m, MonadReader Alias.DefinitionSet m)
           => HereDocAliasT m AndOrList
 andOrList = AndOrList <$> pipeline <*> many conditionalPipeline <*> sep
   where sep = lift $ separatorOp <|> return False
+
+-- | Parses a sequence of one or more and-or lists surrounded by optional
+-- linebreaks.
+compoundList :: (MonadParser m, MonadReader Alias.DefinitionSet m)
+             => HereDocAliasT m (NonEmpty AndOrList)
+compoundList = linebreak *> some' (andOrList <* linebreak)
 
 completeLineBody :: (MonadParser m, MonadReader Alias.DefinitionSet m)
                  => HereDocAliasT m [AndOrList]

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -31,7 +31,7 @@ module Flesh.Language.Parser.Syntax (
   HereDocAliasT,
   -- * Tokens
   backslashed, doubleQuoteUnit, doubleQuote, singleQuote, wordUnit, tokenTill,
-  normalToken, aliasableToken, reserved,
+  normalToken, reservedOrToken, aliasableToken, reserved,
   -- * Syntax
   redirect, hereDocContent, newlineHD, whitesHD, linebreak,
   simpleCommand, command, pipeSequence, pipeline, conditionalPipeline,
@@ -113,6 +113,15 @@ tokenTill a = notFollowedBy a >> (require $ Token <$> wordUnit `someTill` a)
 -- whitespaces after the token.
 normalToken :: MonadParser m => m Token
 normalToken = tokenTill endOfToken <* whites
+
+-- | Returns the token text in Left if the argument word 'isReserved',
+-- otherwise the argument itself in Right.
+reservedOrToken :: Token -> Either (Positioned T.Text) Token
+reservedOrToken t = maybe (Right t) Left $ do
+  t' <- tokenText t
+  guard $ isReserved t'
+  return (p, t')
+    where Token ((p, _) :| _) = t -- position of the first word unit
 
 -- | Like 'normalToken', but tries to perform alias substitution on the
 -- result.

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -31,8 +31,7 @@ module Flesh.Language.Parser.Syntax (
   HereDocAliasT,
   -- * Tokens
   backslashed, doubleQuoteUnit, doubleQuote, singleQuote, wordUnit, tokenTill,
-  normalToken, reservedOrToken, aliasableToken, reservedOrAliasOrToken,
-  literal,
+  normalToken, reservedOrToken, reservedOrAliasOrToken, literal,
   -- * Syntax
   -- ** Basic parts
   redirect, hereDocContent, newlineHD, whitesHD, linebreak,
@@ -132,20 +131,6 @@ reservedOrToken t = maybe (Right t) Left $ do
   guard $ isReserved t'
   return (p, t')
     where Token ((p, _) :| _) = t -- position of the first word unit
-
--- | Like 'normalToken', but tries to perform alias substitution on the
--- result.
-aliasableToken :: (MonadParser m, MonadReader Alias.DefinitionSet m)
-               => AliasT m Token
-aliasableToken = AliasT $ do
-  t <- normalToken
-  let inv Nothing = Just t
-      inv (Just ()) = Nothing
-      tt = MaybeT $ return $ tokenText t
-      pos = fst $ NE.head $ tokenUnits t
-   in fmap inv $ runMaybeT $ tt >>= substituteAlias pos
-   -- TODO substitute the next token if the current substitute ends with a
-   -- blank.
 
 -- | Parses a normal non-empty token followed by optional whitespaces.
 -- Reserved words are returned in Left as by 'reservedOrToken'.

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -264,6 +264,17 @@ simpleCommandArguments = arg <*> simpleCommandArguments <|> pure ([], [], [])
         normalToken' = lift normalToken
 -- TODO global aliases
 
+-- | Parses a simple command but the first token.
+--
+-- The first token of the simple command is not parsed by this parser. It must
+-- have been parsed by another parser and must be passed as the argument.
+simpleCommandTail :: (MonadParser m, MonadReader Alias.DefinitionSet m)
+                  => Token -> HereDocAliasT m Command
+simpleCommandTail t1 = toCommand . consToken t1 <$> simpleCommandArguments
+  where toCommand (ts, as, rs) = SimpleCommand ts as rs
+        consToken t (ts, as, rs) = (t:ts, as, rs)
+-- TODO assignments
+
 -- | Parses a simple command. Skips whitespaces after the command.
 simpleCommand :: (MonadParser m, MonadReader Alias.DefinitionSet m)
               => HereDocAliasT m Command

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -37,7 +37,7 @@ module Flesh.Language.Parser.Syntax (
   -- ** Basic parts
   redirect, hereDocContent, newlineHD, whitesHD, linebreak,
   -- ** Commands
-  simpleCommand, groupingTail, command,
+  groupingTail, command,
   -- ** Lists
   pipeSequence, pipeline, conditionalPipeline, andOrList, compoundList,
   completeLine) where
@@ -277,21 +277,6 @@ simpleCommandTail :: (MonadParser m, MonadReader Alias.DefinitionSet m)
 simpleCommandTail t1 = toCommand . consToken t1 <$> simpleCommandArguments
   where toCommand (ts, as, rs) = SimpleCommand ts as rs
         consToken t (ts, as, rs) = (t:ts, as, rs)
--- TODO assignments
-
--- | Parses a simple command. Skips whitespaces after the command.
-simpleCommand :: (MonadParser m, MonadReader Alias.DefinitionSet m)
-              => HereDocAliasT m Command
-simpleCommand = f <$> nonEmptyBody
-  where f (ts, as, rs) = SimpleCommand ts as rs
-        nonEmptyBody = fRedir <$> redirect' <*> requireHD body <|>
-          fToken <$> aliasableToken' <*> simpleCommandArguments
-        body = nonEmptyBody <|> pure ([], [], [])
-        redirect' = mapHereDocT lift redirect
-        aliasableToken' = lift aliasableToken
-        fRedir r (ts, as, rs) = (ts, as, r:rs)
-        fToken t (ts, as, rs) = (t:ts, as, rs)
--- TODO global aliases
 -- TODO assignments
 
 -- | Parses a grouping except the first open brace, which must have just been

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -66,6 +66,10 @@ import Prelude hiding (words)
 -- | Combination of 'HereDocT' and 'AliasT'.
 type HereDocAliasT m a = HereDocT (AliasT m) a
 
+joinAliasHereDocAliasT :: MonadParser m
+                       => AliasT m (HereDocAliasT m a) -> HereDocAliasT m a
+joinAliasHereDocAliasT = HereDocT . join . lift . fmap runHereDocT
+
 -- | Parses a backslash-escaped character that is parsed by the given parser.
 backslashed :: MonadParser m
             => m (Positioned Char) -> m (Positioned DoubleQuoteUnit)

--- a/src/Flesh/Language/Syntax/Print.hs
+++ b/src/Flesh/Language/Syntax/Print.hs
@@ -35,6 +35,7 @@ module Flesh.Language.Syntax.Print (
 
 import Control.Monad.State.Strict
 import Control.Monad.Writer.Lazy
+import Data.Foldable
 import Data.List.NonEmpty (NonEmpty(..))
 import Flesh.Language.Syntax
 
@@ -116,6 +117,12 @@ instance ListPrintable Redirection where
             showSpace'
             prints r'
 
+instance Printable CompoundCommand where
+  prints (Grouping ls) = do
+    tell' $ showString "{ "
+    printList (toList ls)
+    tell' $ showString " }"
+
 instance Printable Command where
   prints (SimpleCommand [] [] []) = return ()
   prints c@(SimpleCommand _ _ []) = tell' $ shows c
@@ -124,6 +131,7 @@ instance Printable Command where
     prints (SimpleCommand ts as [])
     showSpace'
     printList rs
+  prints (CompoundCommand (_, cc)) = prints cc
   prints FunctionDefinition = undefined -- TODO
 
 instance Printable Pipeline where


### PR DESCRIPTION
This is a rework of #40.

- [x] Define grouping syntax.
- [x] Print grouping syntax.
- Parse grouping syntax.
  - [x] Parse reserved words.
  - [x] Substitute aliases after checking for reserved words.
  - [x] Parse compound lists.
  - [x] Parse grouping syntax.
  - [x] Parse compound commands as commands.
  - [x] Rename `reserved` to `literal`.

----

- [x] Define error for compound command parse error.
- [x] Remove unnecessary definitions such as `simpleCommand`.
- [x] Test `compoundCommand`. Split `groupingTail`.
- [x] Test missing close brace.