### PR TITLE
Refine Functor/Applicative/Monad instances

### DIFF
--- a/hspec-src/Flesh/Language/Parser/TestUtil.hs
+++ b/hspec-src/Flesh/Language/Parser/TestUtil.hs
@@ -41,10 +41,13 @@ newtype Overrun a = Overrun {
 
 instance Functor Overrun where
   fmap f = Overrun . fmap f . runOverrun
+  a <$ Overrun b = Overrun (a <$ b)
 
 instance Applicative Overrun where
   pure = Overrun . pure
   Overrun a <*> Overrun b = Overrun (a <*> b)
+  Overrun a  *> Overrun b = Overrun (a  *> b)
+  Overrun a <*  Overrun b = Overrun (a <*  b)
 
 instance Monad Overrun where
   Overrun a >>= f = Overrun (a >>= runOverrun . f)

--- a/src/Flesh/Language/Parser/Alias.hs
+++ b/src/Flesh/Language/Parser/Alias.hs
@@ -78,22 +78,11 @@ instance MonadTrans AliasT where
 
 instance Functor m => Functor (AliasT m) where
   fmap f = mapAliasT $ fmap $ fmap f
+  (<$) x = mapAliasT (Just x <$)
 
 instance MonadParser m => Applicative (AliasT m) where
   pure = AliasT . pure . Just
-  af <*> ax = AliasT $ do
-    p1 <- currentPosition
-    mf <- runAliasT af
-    case mf of
-      Nothing -> pure Nothing
-      Just f -> do
-        p2 <- currentPosition
-        let parseRhs = do
-              mx <- runAliasT ax
-              case mx of
-                Nothing -> if p1 == p2 then pure Nothing else parseRhs
-                Just x -> pure $ Just $ f x
-         in parseRhs
+  af <*> ax = af >>= (<$> ax)
 
 instance MonadParser m => Alternative (AliasT m) where
   empty = lift empty

--- a/src/Flesh/Language/Pretty.hs
+++ b/src/Flesh/Language/Pretty.hs
@@ -108,13 +108,17 @@ runCursorT' = fmap fst . flip runStateT p . runCursorT
 
 instance Functor m => Functor (CursorT m) where
   fmap f = CursorT . fmap f . runCursorT
+  a <$ CursorT b = CursorT (a <$ b)
 
 instance Monad m => Applicative (CursorT m) where
   pure = CursorT . pure
   CursorT a <*> CursorT b = CursorT (a <*> b)
+  CursorT a  *> CursorT b = CursorT (a  *> b)
+  CursorT a <*  CursorT b = CursorT (a <*  b)
 
 instance Monad m => Monad (CursorT m) where
   CursorT a >>= f = CursorT (a >>= runCursorT . f)
+  CursorT a >> CursorT b = CursorT (a >> b)
 
 instance MonadError e m => MonadError e (CursorT m) where
   throwError = CursorT . throwError


### PR DESCRIPTION
Some function definitions are added for better performance.
The (<*>) function of the Applicative (AliasT m) instance is redefined
in terms of (>>=) because the previous definition did not seem to
benefit performance while mostly copying the definition from (>>=).