### PR TITLE
Define token parser that takes blank-ending alias into account

### DIFF
--- a/hspec-src/Flesh/Language/Parser/Syntax_TokenSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/Syntax_TokenSpec.hs
@@ -15,6 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -}
 
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE Trustworthy #-}
 
 module Flesh.Language.Parser.Syntax_TokenSpec (spec) where
@@ -133,6 +134,67 @@ spec = do
 
     context "rejects empty token" $ do
       expectFailure "\\\n)" (tokenTill (lc (char ')'))) Soft UnknownReason 0
+
+  describe "identifiedToken" $ do
+    let ip f a = do
+          r <- runAliasT $ fst <$> identifiedToken f a
+          case r of
+            Nothing -> failure
+            Just p -> return p
+        ik f a = runAliasT $ snd <$> identifiedToken f a
+        ik' f a = reparse $ snd <$> identifiedToken f a
+
+    context "returns current position" $ do
+      expectPosition "foo;" (ip (const True) True) 0
+
+    context "any token can be identified as reserved if accepted" $ do
+      expectShow "foo" ";" (ik (const True)  True) "Just (Reserved \"foo\")"
+      expectShow "if" ";"  (ik (const True)  True) "Just (Reserved \"if\")"
+      expectShow "w" ";"   (ik (== pack "w") True) "Just (Reserved \"w\")"
+
+    context "no token can be identified as reserved if rejected" $ do
+      expectShow "foo" ";" (ik (const False) True) "Just (Normal foo)"
+      expectShow "if" ";"  (ik (const False) True) "Just (Normal if)"
+      expectShow "w" ";"   (ik (/= pack "w") True) "Just (Normal w)"
+
+    context "quoted tokens are not identified as reserved" $ do
+      expectShow "f\\oo" ";" (ik (const True) True) "Just (Normal f\\oo)"
+      expectShow "f'o'o" ";" (ik (const True) True) "Just (Normal f'o'o)"
+      expectShow "f\"o\"o" ";" (ik (const True) True) "Just (Normal f\"o\"o)"
+
+    context "doesn't perform alias substitution on reserved words" $ do
+      expectShow defaultAliasName ";" (ik (const True) True) $
+        "Just (Reserved \"" ++ defaultAliasName ++ "\")"
+
+    context "modifies pending input on alias substitution" $ do
+      expectSuccessEof defaultAliasName "" (ik (const False) True >> readAll)
+        defaultAliasValue
+
+    it "returns nothing after alias substitution" $
+      let e = runFullInputTesterWithDummyPositions (ik (const False) True)
+                defaultAliasName
+       in fmap fst e `shouldBe` Right Nothing
+
+    it "stops alias substitution on recursion" $
+      let e = runFullInputTesterWithDummyPositions
+                ((,) <$> ik' (const False) True <*> readAll) defaultAliasName
+          f ((l, r), _) = (show l, r)
+          ex = "Normal " ++ defaultAliasName
+       in fmap f e `shouldBe` Right (ex, "--color")
+
+    it "stops alias substitution on exact recursion" $
+      let e = runFullInputTesterWithDummyPositions
+                ((,) <$> ik' (const False) True <*> readAll) recursiveAlias
+          f ((l, r), _) = (show l, r)
+          ex = "Normal " ++ recursiveAlias
+       in fmap f e `shouldBe` Right (ex, "")
+
+    context "doesn't perform alias substitution if disabled" $ do
+      expectShow recursiveAlias ";" (ik (const False) False) $
+        "Just (Normal " ++ recursiveAlias ++ ")"
+
+    context "performs alias substitution after blank-ending substitution" $ do
+      return () -- should be tested elsewhere
 
   describe "reservedOrAliasOrToken" $ do
     let ignorePosition = either (Left . snd) Right

--- a/hspec-src/Flesh/Language/Parser/Syntax_TokenSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/Syntax_TokenSpec.hs
@@ -196,49 +196,6 @@ spec = do
     context "performs alias substitution after blank-ending substitution" $ do
       return () -- should be tested elsewhere
 
-  describe "reservedOrAliasOrToken" $ do
-    let ignorePosition = either (Left . snd) Right
-        rat = runAliasT $ ignorePosition <$> reservedOrAliasOrToken
-        rat' = runAliasT $ ignorePosition <$> reservedOrAliasOrToken
-
-    context "returns unmatched token" $ do
-      expectShow "foo" ";" rat' "Just (Right foo)"
-
-    context "returns quoted token" $ do
-      expectShow "f\\oo" ";" rat' "Just (Right f\\oo)"
-      expectShow "f\"o\"o" "&" rat' "Just (Right f\"o\"o)"
-      expectShow "f'o'o" ")" rat' "Just (Right f'o'o)"
-
-    context "returns non-constant token" $ do
-      expectShow "f${1}o" ";" rat' "Just (Right f${1}o)"
-
-    context "returns reserved word" $ do
-      expectShow "!" ";" rat' "Just (Left \"!\")"
-      expectShowEof reservedWordAliasName "" rat "Just (Left \"while\")"
-
-    it "doesn't perform alias substitution on reserved words" $
-      let e = runFullInputTesterAlias rat reservedWordAliasDefinitions s
-          s = spread (dummyPosition s') s'
-          s' = reservedWordAliasName
-       in fmap (show . fst) e `shouldBe` Right "Just (Left \"while\")"
-
-    context "modifies pending input on alias subsitution" $ do
-      expectSuccessEof defaultAliasName "" (rat >> readAll) defaultAliasValue
-
-    it "returns nothing after substitution" $
-      let e = runFullInputTesterWithDummyPositions rat defaultAliasName
-       in fmap fst e `shouldBe` Right Nothing
-
-    it "stops alias substitution on recursion" $
-      let e = runFullInputTesterWithDummyPositions
-                (reparse reservedOrAliasOrToken >> readAll) defaultAliasName
-       in fmap fst e `shouldBe` Right "--color"
-
-    it "stops alias substitution on exact recursion" $
-      let e = runFullInputTesterWithDummyPositions
-                (reparse reservedOrAliasOrToken >> readAll) recursiveAlias
-       in fmap fst e `shouldBe` Right ""
-
   describe "literal" $ do
     context "returns matching unquoted token" $ do
       expectShowEof "! " "" (literal (pack "!")) "!"

--- a/src/Flesh/Data/Char.hs
+++ b/src/Flesh/Data/Char.hs
@@ -1,0 +1,38 @@
+{-
+Copyright (C) 2017 WATANABE Yuki <magicant@wonderwand.net>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-}
+
+{-# LANGUAGE Safe #-}
+
+{-|
+Copyright   : (C) 2017 WATANABE Yuki
+License     : GPL-2
+Portability : portable
+
+This module extends the Data.Char module, adding some useful functions.
+-}
+module Flesh.Data.Char (
+  module Data.Char,
+  isBlank) where
+
+import Data.Char
+
+-- | Selects blank characters.
+isBlank :: Char -> Bool
+isBlank c | ord c <= 0x7F = c == '\t' || c == ' '
+          | otherwise     = isSpace c
+
+-- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Parser/Alias.hs
+++ b/src/Flesh/Language/Parser/Alias.hs
@@ -40,7 +40,7 @@ module Flesh.Language.Parser.Alias (
 
 import Control.Applicative (Alternative, empty, (<|>))
 import Control.Monad (MonadPlus, guard)
-import Control.Monad.Reader (MonadReader, ReaderT, ask)
+import Control.Monad.Reader (MonadReader, ReaderT, ask, local, reader)
 import Control.Monad.Trans.Class (MonadTrans, lift)
 import Control.Monad.Trans.Maybe (MaybeT(MaybeT), runMaybeT)
 import Data.Map.Strict (lookup)
@@ -137,6 +137,11 @@ instance MonadParser m => MonadInputRecord (AliasT m) where
 instance (MonadParser m, MonadError e m) => MonadError e (AliasT m) where
   throwError = lift . throwError
   catchError m f = AliasT $ catchError (runAliasT m) (runAliasT . f)
+
+instance (MonadParser m, MonadReader r m) => MonadReader r (AliasT m) where
+  ask = lift ask
+  local f = mapAliasT $ local f
+  reader f = lift $ reader f
 
 instance MonadParser m => MonadParser (AliasT m)
 

--- a/src/Flesh/Language/Parser/Lex.hs
+++ b/src/Flesh/Language/Parser/Lex.hs
@@ -36,10 +36,10 @@ module Flesh.Language.Parser.Lex (
   reservedOpenBrace, reservedCloseBrace, isReserved) where
 
 import Control.Applicative (many, (<|>))
-import Data.Char (isDigit, isSpace, ord)
 import qualified Data.List.NonEmpty as NE
 import Data.Set (Set, fromList, member)
 import Data.Text (Text, pack)
+import Flesh.Data.Char (isBlank, isDigit)
 import Flesh.Source.Position
 import Flesh.Language.Parser.Char
 import Flesh.Language.Parser.Error
@@ -57,8 +57,6 @@ lc m = many lineContinuation *> m
 
 blank' :: MonadParser m => m (Positioned Char)
 blank' = satisfy isBlank
-  where isBlank c | ord c <= 0x7F = c == '\t' || c == ' '
-                  | otherwise     = isSpace c
 
 -- | Parses a blank character, possibly preceded by line continuations.
 --

--- a/src/Flesh/Language/Parser/Lex.hs
+++ b/src/Flesh/Language/Parser/Lex.hs
@@ -15,12 +15,13 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -}
 
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE Safe #-}
 
 {-|
 Copyright   : (C) 2017 WATANABE Yuki
 License     : GPL-2
-Portability : portable
+Portability : non-portable (flexible contexts)
 
 This module defines utilities for lexical parsing that are specific to the
 shell language.
@@ -33,17 +34,23 @@ module Flesh.Language.Parser.Lex (
   reservedBang, reservedCase, reservedDo, reservedDone, reservedElif,
   reservedElse, reservedEsac, reservedFi, reservedFor, reservedFunction,
   reservedIf, reservedIn, reservedThen, reservedUntil, reservedWhile,
-  reservedOpenBrace, reservedCloseBrace, isReserved) where
+  reservedOpenBrace, reservedCloseBrace, isReserved,
+  -- * Token identification
+  IdentifiedToken(..), identify) where
 
 import Control.Applicative (many, (<|>))
+import Control.Monad.Reader
 import qualified Data.List.NonEmpty as NE
 import Data.Set (Set, fromList, member)
 import Data.Text (Text, pack)
 import Flesh.Data.Char (isBlank, isDigit)
 import Flesh.Source.Position
+import qualified Flesh.Language.Alias as Alias
+import Flesh.Language.Parser.Alias
 import Flesh.Language.Parser.Char
 import Flesh.Language.Parser.Error
 import Flesh.Language.Parser.Input
+import Flesh.Language.Syntax
 import Numeric.Natural (Natural)
 
 -- | Parses a line continuation: a backslash followed by a newline.
@@ -183,5 +190,37 @@ reservedWords = fromList [reservedBang, reservedCase, reservedDo,
 -- | Tests if the argument text is a reserved word token.
 isReserved :: Text -> Bool
 isReserved t = member t reservedWords
+
+-- | Result of token identification.
+data IdentifiedToken =
+  Reserved Text -- ^ reserved word
+  | Normal Token -- ^ normal word token
+  deriving (Eq, Show)
+
+-- | @identify isReserved' isAliasable p t@ identifies a token.
+--
+-- First, if the token is a simple text and @isReserved'@ returns True for it,
+-- then it is identified as Reserved.
+--
+-- Next, if @isAliasable@ is true, the token is tested for an alias. If it
+-- matches a valid alias, substitution is performed.
+--
+-- Otherwise, the token is identified as Normal.
+identify :: (MonadParser m, MonadReader Alias.DefinitionSet m)
+         => (Text -> Bool) -- ^ function that tests if a token is reserved
+         -> Bool -- ^ whether the token should be checked for an alias
+         -> Position -- ^ position of the token to be identified
+         -> Token -- ^ token to be identified
+         -> AliasT m IdentifiedToken
+identify isReserved' isAliasable p t =
+  case tokenText t of
+    Nothing -> return $ Normal t
+    Just tt | isReserved' tt -> return $ Reserved tt
+            | otherwise -> do
+                fromMaybeT $ do
+                  guard isAliasable
+                  substituteAlias p tt
+                return $ Normal t
+-- TODO support global aliases, possibly extending the @isAliasable@ argument
 
 -- vim: set et sw=2 sts=2 tw=78:


### PR DESCRIPTION
- [x] Test if a character is blank.
- [x] Test if a current position is after a blank-ending alias substitution.
- [x] Parse token taking blank-ending alias into account.
  - `isAfterBlankEndingSubstitution` should be tested before `normalToken` is parsed.
- [x] Better rename `normalToken` to `neutralToken`?