### PR TITLE
Command substitution in backquotes

### DIFF
--- a/hspec-src/Flesh/Language/Parser/Syntax_TokenSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/Syntax_TokenSpec.hs
@@ -21,6 +21,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 module Flesh.Language.Parser.Syntax_TokenSpec (spec) where
 
 import Data.Foldable (traverse_)
+import Data.List (elemIndex)
+import Data.Maybe (fromJust)
 import Data.Text (pack)
 import Flesh.Language.Parser.Alias
 import Flesh.Language.Parser.Char
@@ -63,6 +65,33 @@ spec = do
         let isExpectedReason (UnclosedCommandSubstitution p) = index p == 1
             isExpectedReason _ = False
         expectFailureEof' "$(X" dollarExpansion Hard isExpectedReason  3
+
+  describe "backquoteExpansion" $ do
+    let bq_ = backquoteExpansion undefined
+        bqx = backquoteExpansion (const False)
+        bq = backquoteExpansion (`elem` "\\\"$`")
+
+    context "parses empty quotes" $ do
+      expectSuccess "``" "" (snd <$> bq_) (Backquoted "")
+      expectPosition "``" (fst <$> bq_) 0
+
+    context "parses some characters" $ do
+      expectSuccess "`a`" "" (snd <$> bq_) (Backquoted "a")
+      expectSuccess "`''`" "" (snd <$> bq_) (Backquoted "''")
+      expectSuccess "` \t\n`" "" (snd <$> bq_) (Backquoted " \t\n")
+
+    context "ignores line continuations" $ do
+      let s = "\\\n\\\n`\\\nA\\\n\\\nBC\\\n`" 
+      expectSuccess s "" (snd <$> bq_) (Backquoted "ABC")
+      expectPosition s (fst <$> bq_) (fromJust (elemIndex '`' s))
+
+    context "can contain escaped characters" $ do
+      expectSuccess "`\\a\\\\\\b\\$\\c\\%\\d\\\n\\e\\`" "\\z`" (snd <$> bqx)
+        (Backquoted "\\a\\\\\\b\\$\\c\\%\\d\\e\\")
+      expectSuccess "`\\a\\\\\\b\\$\\c\\%\\d\\\n\\e\\`\\z`" "" (snd <$> bq)
+        (Backquoted "\\a\\\\b$\\c\\%\\d\\e`\\z")
+
+    context "fails on unclosed quotes" $ return () -- TODO
 
   describe "doubleQuoteUnit" $ do
     context "parses backslashed backslash" $ do

--- a/hspec-src/Flesh/Language/Parser/Syntax_TokenSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/Syntax_TokenSpec.hs
@@ -91,7 +91,14 @@ spec = do
       expectSuccess "`\\a\\\\\\b\\$\\c\\%\\d\\\n\\e\\`\\z`" "" (snd <$> bq)
         (Backquoted "\\a\\\\b$\\c\\%\\d\\e`\\z")
 
-    context "fails on unclosed quotes" $ return () -- TODO
+    context "fails on unclosed quotes" $ do
+      let p = dummyPosition ""
+          bq_' = backquoteExpansion undefined
+          bq' = backquoteExpansion (`elem` "\\\"$`")
+      expectFailureEof "`" bq_' Hard (UnclosedCommandSubstitution p) 1
+      expectFailureEof "`x" bq_' Hard (UnclosedCommandSubstitution p) 2
+      expectFailureEof "`\\" bq_' Hard (UnclosedCommandSubstitution p) 2
+      expectFailureEof "`\\`" bq' Hard (UnclosedCommandSubstitution p) 3
 
   describe "doubleQuoteUnit" $ do
     context "parses backslashed backslash" $ do

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -115,7 +115,8 @@ backquoteExpansion :: MonadParser m
 backquoteExpansion canEscape = do
   let bq = lc (char '`')
   (p, _) <- bq
-  cs <- require $ backquoteExpansionUnit canEscape `manyTill` bq
+  let bq' = setReason (UnclosedCommandSubstitution p) bq
+  cs <- require $ backquoteExpansionUnit canEscape `manyTill` bq'
   return (p, Backquoted cs)
 
 -- | Parses a double-quote unit, possibly preceded by line continuations.

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -86,9 +86,9 @@ dollarExpansionTail = do
     -- TODO arithmetic expansion
     -- TODO braced parameter expansion
     -- TODO unbraced parameter expansion
-    '(' -> require $ fmap Flesh.Language.Syntax.CommandSubstitution $
-      execCaptureT cmdsubstBody <* closeParan
-      where cmdsubstBody = runReaderT program empty
+    '(' -> require $ f <$> execCaptureT cmdsubstBody <* closeParan
+      where f = Flesh.Language.Syntax.CommandSubstitution . snd . unzip
+            cmdsubstBody = runReaderT program empty
             closeParan = setReason (UnclosedCommandSubstitution p) (char ')')
     _ -> failureOfError (Error MissingExpansionAfterDollar p)
 

--- a/src/Flesh/Language/Syntax.hs
+++ b/src/Flesh/Language/Syntax.hs
@@ -56,7 +56,7 @@ data DoubleQuoteUnit =
     -- | Parameter expansion.
     | Parameter -- FIXME
     -- | @$(...)@
-    | CommandSubstitution [Positioned Char]
+    | CommandSubstitution String
     | Backquoted -- FIXME command substitution
     | Arithmetic -- FIXME
   deriving (Eq)
@@ -65,8 +65,8 @@ instance Show DoubleQuoteUnit where
   showsPrec _ (Char c) = showChar c
   showsPrec _ (Backslashed c) = \s -> '\\':c:s
   showsPrec _ Parameter = id
-  showsPrec _ (CommandSubstitution pcs) =
-    showString "$(" . showString (snd (unzip pcs)) . showChar ')'
+  showsPrec _ (CommandSubstitution cs) =
+    showString "$(" . showString cs . showChar ')'
   showsPrec _ Backquoted = id
   showsPrec _ Arithmetic = id
   -- | Just joins the given units, without enclosing double quotes.


### PR DESCRIPTION
- [x] Define syntax.
- [x] Redefine `doubleQuoteUnit'`, for backslash-escapable characters are different between inside and outside backquotes.
- [x] Parse backquote command substitution.
- [x] Unclosed command substitution error.
