### PR TITLE
Make AliasT satisfy the composition law

### DIFF
--- a/hspec-src/Flesh/Language/Parser/Syntax_CommandSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/Syntax_CommandSpec.hs
@@ -32,8 +32,8 @@ spec :: Spec
 spec = do
   describe "subshell" $ do
     let p = dummyPosition "X"
-        s = runAliasT (fill (snd <$> subshell))
-        s' = runAliasT (fill (snd <$> subshell))
+        s = runAliasT' (fill (snd <$> subshell))
+        s' = runAliasT' (fill (snd <$> subshell))
 
     context "may have one inner command" $ do
       expectShowEof "(foo)" "" s "Just (foo)"
@@ -282,8 +282,8 @@ spec = do
     -- Other tests are omitted because they are the same with whileClauseTail
 
   describe "command" $ do
-    let sc = runAliasT $ fill command
-        sc' = runAliasT $ fill command
+    let sc = runAliasT' $ fill command
+        sc' = runAliasT' $ fill command
 
     context "as simple command" $ do
       context "cannot be empty" $ do

--- a/hspec-src/Flesh/Language/Parser/Syntax_CommandSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/Syntax_CommandSpec.hs
@@ -32,8 +32,8 @@ spec :: Spec
 spec = do
   describe "subshell" $ do
     let p = dummyPosition "X"
-        s = runAliasT' (fill (snd <$> subshell))
-        s' = runAliasT' (fill (snd <$> subshell))
+        s = runAliasT (fill (snd <$> subshell))
+        s' = runAliasT (fill (snd <$> subshell))
 
     context "may have one inner command" $ do
       expectShowEof "(foo)" "" s "Just (foo)"
@@ -86,7 +86,7 @@ spec = do
 
   describe "doGroup" $ do
     let p = dummyPosition "X"
-        dg = toList <$> reparse (fill (doGroup UnclosedDoubleQuote))
+        dg = toList <$> evalAliasT (fill (doGroup UnclosedDoubleQuote))
 
     context "may have one inner command" $ do
       expectShowEof "do foo;done" "" dg "foo"
@@ -112,7 +112,7 @@ spec = do
 
   describe "forClauseTail" $ do
     let p = dummyPosition "X"
-        f = snd <$> reparse (fill (forClauseTail p))
+        f = snd <$> evalAliasT (fill (forClauseTail p))
 
     context "simplest form" $ do
       expectShowEof "var do :; done" "" f "for var do :; done"
@@ -171,7 +171,7 @@ spec = do
   describe "ifClauseTail" $ do
     let p = dummyPosition "X"
         ps = iterate next p
-        i = reparse $ fill $ ifClauseTail p
+        i = evalAliasT $ fill $ ifClauseTail p
         i1 = fst <$> i
         i2 = snd <$> i
 
@@ -245,7 +245,7 @@ spec = do
 
   describe "whileClauseTail" $ do
     let p = dummyPosition "X"
-        w = snd <$> reparse (fill (whileClauseTail p))
+        w = snd <$> evalAliasT (fill (whileClauseTail p))
 
     context "may have one condition command" $ do
       expectShowEof "foo;do :;done" "" w "while foo; do :; done"
@@ -271,7 +271,7 @@ spec = do
 
   describe "untilClauseTail" $ do
     let p = dummyPosition "X"
-        u = snd <$> reparse (fill (untilClauseTail p))
+        u = snd <$> evalAliasT (fill (untilClauseTail p))
 
     context "may have one condition command" $ do
       expectShowEof "foo;do :;done" "" u "until foo; do :; done"
@@ -282,8 +282,8 @@ spec = do
     -- Other tests are omitted because they are the same with whileClauseTail
 
   describe "command" $ do
-    let sc = runAliasT' $ fill command
-        sc' = runAliasT' $ fill command
+    let sc = runAliasT $ fill command
+        sc' = runAliasT $ fill command
 
     context "as simple command" $ do
       context "cannot be empty" $ do

--- a/hspec-src/Flesh/Language/Parser/Syntax_ListSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/Syntax_ListSpec.hs
@@ -31,8 +31,8 @@ import Test.Hspec (Spec, context, describe, it, shouldBe)
 spec :: Spec
 spec = do
   describe "pipeSequence" $ do
-    let ps = runAliasT' $ fill $ toList <$> pipeSequence
-        ps' = runAliasT' $ fill $ toList <$> pipeSequence
+    let ps = runAliasT $ fill $ toList <$> pipeSequence
+        ps' = runAliasT $ fill $ toList <$> pipeSequence
 
     context "can be one simple command" $ do
       expectShowEof "foo bar" "" ps "Just [foo bar]"
@@ -50,8 +50,8 @@ spec = do
       expectShow "a " "\n|b" ps' "Just [a]"
 
   describe "pipeline" $ do
-    let p = runAliasT' $ fill pipeline
-        p' = runAliasT' $ fill pipeline
+    let p = runAliasT $ fill pipeline
+        p' = runAliasT $ fill pipeline
 
     context "can start with !" $ do
       expectShowEof "! foo bar " "\n" p "Just ! foo bar"
@@ -66,8 +66,8 @@ spec = do
       expectFailure    "! )" p' Hard (MissingCommandAfter "!") 2
 
   describe "conditionalPipeline" $ do
-    let cp = runAliasT' $ fill conditionalPipeline
-        cp' = runAliasT' $ fill conditionalPipeline
+    let cp = runAliasT $ fill conditionalPipeline
+        cp' = runAliasT $ fill conditionalPipeline
 
     context "can start with && followed by pipeline" $ do
       expectShowEof "&&foo" "" cp "Just && foo"
@@ -91,9 +91,9 @@ spec = do
       expectFailureEof ";"     cp  Soft UnknownReason 0
 
   describe "andOrList" $ do
-    let aol = fmap (fmap ($ False)) $ runAliasT' $ fill andOrList
-        aol' = fmap (fmap ($ False)) $ runAliasT' $ fill andOrList
-        aol'' = fmap (fmap ($ True)) $ runAliasT' $ fill andOrList
+    let aol = fmap (fmap ($ False)) $ runAliasT $ fill andOrList
+        aol' = fmap (fmap ($ False)) $ runAliasT $ fill andOrList
+        aol'' = fmap (fmap ($ True)) $ runAliasT $ fill andOrList
 
     context "consists of pipelines" $ do
       expectShowEof "foo" ";" aol "Just foo;"
@@ -114,8 +114,8 @@ spec = do
       expectShowEof "foo && bar" "" aol "Just foo && bar;"
 
   describe "compoundList" $ do
-    let cl = runAliasT' $ fill $ toList <$> compoundList
-        cl' = runAliasT' $ fill $ toList <$> compoundList
+    let cl = runAliasT $ fill $ toList <$> compoundList
+        cl' = runAliasT $ fill $ toList <$> compoundList
 
     context "is not empty" $ do
       expectShow "foo" ";;" cl' "Just foo"

--- a/hspec-src/Flesh/Language/Parser/Syntax_ListSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/Syntax_ListSpec.hs
@@ -31,8 +31,8 @@ import Test.Hspec (Spec, context, describe, it, shouldBe)
 spec :: Spec
 spec = do
   describe "pipeSequence" $ do
-    let ps = runAliasT $ fill $ toList <$> pipeSequence
-        ps' = runAliasT $ fill $ toList <$> pipeSequence
+    let ps = runAliasT' $ fill $ toList <$> pipeSequence
+        ps' = runAliasT' $ fill $ toList <$> pipeSequence
 
     context "can be one simple command" $ do
       expectShowEof "foo bar" "" ps "Just [foo bar]"
@@ -50,8 +50,8 @@ spec = do
       expectShow "a " "\n|b" ps' "Just [a]"
 
   describe "pipeline" $ do
-    let p = runAliasT $ fill pipeline
-        p' = runAliasT $ fill pipeline
+    let p = runAliasT' $ fill pipeline
+        p' = runAliasT' $ fill pipeline
 
     context "can start with !" $ do
       expectShowEof "! foo bar " "\n" p "Just ! foo bar"
@@ -66,8 +66,8 @@ spec = do
       expectFailure    "! )" p' Hard (MissingCommandAfter "!") 2
 
   describe "conditionalPipeline" $ do
-    let cp = runAliasT $ fill conditionalPipeline
-        cp' = runAliasT $ fill conditionalPipeline
+    let cp = runAliasT' $ fill conditionalPipeline
+        cp' = runAliasT' $ fill conditionalPipeline
 
     context "can start with && followed by pipeline" $ do
       expectShowEof "&&foo" "" cp "Just && foo"
@@ -91,9 +91,9 @@ spec = do
       expectFailureEof ";"     cp  Soft UnknownReason 0
 
   describe "andOrList" $ do
-    let aol = fmap (fmap ($ False)) $ runAliasT $ fill andOrList
-        aol' = fmap (fmap ($ False)) $ runAliasT $ fill andOrList
-        aol'' = fmap (fmap ($ True)) $ runAliasT $ fill andOrList
+    let aol = fmap (fmap ($ False)) $ runAliasT' $ fill andOrList
+        aol' = fmap (fmap ($ False)) $ runAliasT' $ fill andOrList
+        aol'' = fmap (fmap ($ True)) $ runAliasT' $ fill andOrList
 
     context "consists of pipelines" $ do
       expectShowEof "foo" ";" aol "Just foo;"
@@ -114,8 +114,8 @@ spec = do
       expectShowEof "foo && bar" "" aol "Just foo && bar;"
 
   describe "compoundList" $ do
-    let cl = runAliasT $ fill $ toList <$> compoundList
-        cl' = runAliasT $ fill $ toList <$> compoundList
+    let cl = runAliasT' $ fill $ toList <$> compoundList
+        cl' = runAliasT' $ fill $ toList <$> compoundList
 
     context "is not empty" $ do
       expectShow "foo" ";;" cl' "Just foo"

--- a/hspec-src/Flesh/Language/Parser/Syntax_TokenSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/Syntax_TokenSpec.hs
@@ -224,11 +224,11 @@ spec = do
 
   describe "identifiedToken" $ do
     let ip f a a' = do
-          r <- runAliasT $ fst <$> identifiedToken f a a'
+          r <- runAliasT' $ fst <$> identifiedToken f a a'
           case r of
             Nothing -> failure
             Just p -> return p
-        ik f a a' = runAliasT $ snd <$> identifiedToken f a a'
+        ik f a a' = runAliasT' $ snd <$> identifiedToken f a a'
         ikReserved r = ik r True True
         ikAllReserved = ikReserved (const True)
         ikNoReserved = ikReserved (const False)

--- a/hspec-src/Flesh/Language/Parser/Syntax_TokenSpec.hs
+++ b/hspec-src/Flesh/Language/Parser/Syntax_TokenSpec.hs
@@ -224,18 +224,18 @@ spec = do
 
   describe "identifiedToken" $ do
     let ip f a a' = do
-          r <- runAliasT' $ fst <$> identifiedToken f a a'
+          r <- runAliasT $ fst <$> identifiedToken f a a'
           case r of
             Nothing -> failure
             Just p -> return p
-        ik f a a' = runAliasT' $ snd <$> identifiedToken f a a'
+        ik f a a' = runAliasT $ snd <$> identifiedToken f a a'
         ikReserved r = ik r True True
         ikAllReserved = ikReserved (const True)
         ikNoReserved = ikReserved (const False)
         ikNoReserved' = ikReserved (const False)
         ikAlias a = ik (const False) a True
         ikAssignment a = ik (const False) True a
-        ir f a a' = reparse $ snd <$> identifiedToken f a a'
+        ir f a a' = evalAliasT $ snd <$> identifiedToken f a a'
         irDefault = ir (const False) True True
 
     context "returns current position" $ do

--- a/src/Flesh/Language/Parser/Alias.hs
+++ b/src/Flesh/Language/Parser/Alias.hs
@@ -35,9 +35,8 @@ module Flesh.Language.Parser.Alias (
   ContextT,
   -- * AliasT
   AliasT(..), mapAliasT, runAliasT, evalAliasT, fromMaybeT,
-  AliasT'(..), mapAliasT', toMaybeT', fromMaybeT',
   -- * Helper functions
-  isAfterBlankEndingSubstitution, substituteAlias, reparse) where
+  isAfterBlankEndingSubstitution, substituteAlias) where
 
 import Control.Applicative (Alternative, empty, (<|>))
 import Control.Monad (MonadPlus, ap, guard)
@@ -165,96 +164,6 @@ instance MonadReader r m => MonadReader r (AliasT m) where
 
 instance MonadParser m => MonadParser (AliasT m)
 
--- | Monad transformer that represents results of parse that may be
--- interrupted by alias substitution.
---
--- If alias substitution occurs on the first token in the parser, the result
--- will be 'Nothing' and the parser must be applied again.
---
--- The '<*>' and '>>=' operators for 'AliasT' behave differently from those of
--- 'MaybeT'. They try to re-parse the right hand side if it returned 'Nothing'
--- and the left hand side consumed any input characters. In other words, the
--- right hand side is implicitly re-parsed if the left hand side was
--- successfully parsed as a non-empty non-terminal.
-newtype AliasT' m a = AliasT' {runAliasT' :: m (Maybe a)}
-
--- | Modifies the content of AliasT.
-mapAliasT' :: (m (Maybe a) -> n (Maybe b)) -> AliasT' m a -> AliasT' n b
-mapAliasT' f = AliasT' . f . runAliasT'
-
-inverse :: Functor m => m (Maybe a) -> m (Maybe ())
-inverse = fmap inverse'
-  where inverse' Nothing = Just ()
-        inverse' (Just _) = Nothing
-
--- | Converts an 'AliasT' monad to a 'MaybeT' monad.
---
--- Although 'AliasT' and 'MaybeT' share the same value type @m (Maybe a)@,
--- they are semantically inverse: The Nothing value of 'AliasT' means the
--- parser has been aborted due to alias substitution, while that of 'MaybeT'
--- means alias substitution is not applicable in the current parsing state.
--- Hence, 'toMaybeT' inverts Nothing and Just values.
-toMaybeT' :: Functor m => AliasT' m a -> MaybeT m ()
-toMaybeT' = MaybeT . inverse . runAliasT'
-
--- | The inverse of 'toMaybeT'.
-fromMaybeT' :: Functor m => MaybeT m a -> AliasT' m ()
-fromMaybeT' = AliasT' . inverse . runMaybeT
-
-instance MonadTrans AliasT' where
-  lift = AliasT' . fmap Just
-
-instance Functor m => Functor (AliasT' m) where
-  fmap f = mapAliasT' $ fmap $ fmap f
-  (<$) x = mapAliasT' (Just x <$)
-
-instance MonadParser m => Applicative (AliasT' m) where
-  pure = AliasT' . pure . Just
-  af <*> ax = af >>= (<$> ax)
-
-instance MonadParser m => Alternative (AliasT' m) where
-  empty = lift empty
-  a <|> b = AliasT' $ runAliasT' a <|> runAliasT' b
-
-instance MonadParser m => Monad (AliasT' m) where
-  return = pure
-  ax >>= af = AliasT' $ do
-    p1 <- currentPosition
-    mx <- runAliasT' ax
-    case mx of
-      Nothing -> return Nothing
-      Just x -> do
-        p2 <- currentPosition
-        let parseRhs = do
-              mb <- runAliasT' $ af x
-              case mb of
-                Nothing -> if p1 == p2 then pure Nothing else parseRhs
-                Just b -> pure $ Just b
-         in parseRhs
-
-instance MonadParser m => MonadPlus (AliasT' m)
-
-instance MonadParser m => MonadInput (AliasT' m) where
-  popChar = lift popChar
-  lookahead = mapAliasT' lookahead
-  peekChar = lift peekChar
-  currentPosition = lift currentPosition
-  pushChars = lift . pushChars
-
-instance MonadParser m => MonadInputRecord (AliasT' m) where
-  reverseConsumedChars = lift reverseConsumedChars
-
-instance (MonadParser m, MonadError e m) => MonadError e (AliasT' m) where
-  throwError = lift . throwError
-  catchError m f = AliasT' $ catchError (runAliasT' m) (runAliasT' . f)
-
-instance (MonadParser m, MonadReader r m) => MonadReader r (AliasT' m) where
-  ask = lift ask
-  local f = mapAliasT' $ local f
-  reader f = lift $ reader f
-
-instance MonadParser m => MonadParser (AliasT' m)
-
 -- | Tests if the current position is after an alias substitution whose value
 -- ends with a blank.
 isAfterBlankEndingSubstitution :: MonadInputRecord m => m Bool
@@ -301,15 +210,5 @@ substituteAlias pos' t = do
       pos = Position frag 0
       cs = unposition $ spread pos v
   pushChars cs
-
--- | Modifies a parser so that it retries parsing while it is failing due to
--- alias substitution.
-reparse :: Monad m => AliasT' m a -> m a
-reparse a = reparse_a
-  where reparse_a = do
-          m <- runAliasT' a
-          case m of
-            Nothing -> reparse_a
-            Just v -> return v
 
 -- vim: set et sw=2 sts=2 tw=78:

--- a/src/Flesh/Language/Parser/Lex.hs
+++ b/src/Flesh/Language/Parser/Lex.hs
@@ -222,13 +222,13 @@ identify :: (MonadParser m, MonadReader Alias.DefinitionSet m)
          -> Bool -- ^ whether the token should be checked for an assignment
          -> Position -- ^ position of the token to be identified
          -> Token -- ^ token to be identified
-         -> AliasT' m IdentifiedToken
+         -> AliasT m IdentifiedToken
 identify isReserved' isAliasable isAssignable p t =
   case tokenText t of
     Nothing -> aon
     Just tt | isReserved' tt -> return $ Reserved tt
             | otherwise -> do
-                fromMaybeT' $ do
+                fromMaybeT $ do
                   guard isAliasable
                   substituteAlias p tt
                 aon

--- a/src/Flesh/Language/Parser/Lex.hs
+++ b/src/Flesh/Language/Parser/Lex.hs
@@ -222,13 +222,13 @@ identify :: (MonadParser m, MonadReader Alias.DefinitionSet m)
          -> Bool -- ^ whether the token should be checked for an assignment
          -> Position -- ^ position of the token to be identified
          -> Token -- ^ token to be identified
-         -> AliasT m IdentifiedToken
+         -> AliasT' m IdentifiedToken
 identify isReserved' isAliasable isAssignable p t =
   case tokenText t of
     Nothing -> aon
     Just tt | isReserved' tt -> return $ Reserved tt
             | otherwise -> do
-                fromMaybeT $ do
+                fromMaybeT' $ do
                   guard isAliasable
                   substituteAlias p tt
                 aon

--- a/src/Flesh/Language/Parser/Lex.hs
+++ b/src/Flesh/Language/Parser/Lex.hs
@@ -222,15 +222,13 @@ identify :: (MonadParser m, MonadReader Alias.DefinitionSet m)
          -> Bool -- ^ whether the token should be checked for an assignment
          -> Position -- ^ position of the token to be identified
          -> Token -- ^ token to be identified
-         -> AliasT m IdentifiedToken
+         -> m IdentifiedToken
 identify isReserved' isAliasable isAssignable p t =
   case tokenText t of
     Nothing -> aon
     Just tt | isReserved' tt -> return $ Reserved tt
             | otherwise -> do
-                fromMaybeT $ do
-                  guard isAliasable
-                  substituteAlias p tt
+                when isAliasable $ substituteAlias p tt
                 aon
     where aon = return $ aon' t
           aon' = if isAssignable then assignmentOrNormal else Normal

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -68,10 +68,10 @@ import Flesh.Source.Position
 import Numeric.Natural (Natural)
 
 -- | Combination of 'HereDocT' and 'AliasT'.
-type HereDocAliasT m a = HereDocT (AliasT m) a
+type HereDocAliasT m a = HereDocT (AliasT' m) a
 
 joinAliasHereDocAliasT :: MonadParser m
-                       => AliasT m (HereDocAliasT m a) -> HereDocAliasT m a
+                       => AliasT' m (HereDocAliasT m a) -> HereDocAliasT m a
 joinAliasHereDocAliasT = HereDocT . join . lift . fmap runHereDocT
 
 -- | Parses a backslash-escaped character that satisfies the given predicate.
@@ -198,17 +198,17 @@ identifiedToken :: (MonadParser m, MonadReader Alias.DefinitionSet m)
                 -- argument is ignored.
                 -> Bool
                 -- ^ Whether the token should be checked for an assignment.
-                -> AliasT m (Positioned IdentifiedToken)
+                -> AliasT' m (Positioned IdentifiedToken)
 identifiedToken isReserved' isAliasable isAssignable = do
   iabes <- isAfterBlankEndingSubstitution
   pos <- currentPosition
-  it <- AliasT $ do
+  it <- AliasT' $ do
     t <- neutralToken
-    runAliasT $ identify isReserved' (isAliasable || iabes) isAssignable pos t
+    runAliasT' $ identify isReserved' (isAliasable || iabes) isAssignable pos t
   return (pos, it)
 
 aliasableToken :: (MonadParser m, MonadReader Alias.DefinitionSet m)
-               => AliasT m Token
+               => AliasT' m Token
 aliasableToken = do
   t <- identifiedToken (const False) True False
   case snd t of
@@ -372,7 +372,7 @@ braceGroupTail p = do
 
 -- | Parses an "in" clause of a for loop.
 inClause :: (MonadParser m, MonadReader Alias.DefinitionSet m)
-         => AliasT m [Token]
+         => AliasT' m [Token]
 inClause = lift (literal reservedIn) *> many aliasableToken
 
 -- | Parses a 'compoundList' surrounded with the "do" and "done" keywords.


### PR DESCRIPTION
The previous definition of the `Applicative (AliasT m)` and `Monad (AliasT m)` instances did not satisfy the composition law, thus they were not truly applicative or monadic.

Fixes #74.

- [x] Rename old `AliasT`.
- [x] Define new `AliasT`.
- [x] Migrate to use the new `AliasT`.
- [x] Remove the old `AliasT`.
- [x] Recheck the applicative and monad laws.
- [x] Consider refactoring the `>>=` method.
- [x] Consider rewriting `substituteAlias`.
- [x] Can `substituteAlias` be of type `m ()` rather than `AliasT m ()`?
- [ ] Consider hiding `getAliasT`.
- [ ] Consider renaming `AliasT` to `ReparseT`.
