### PR TITLE
Refine alias handling monad

### DIFF
--- a/hspec-src/Flesh/Language/Parser/TestUtil.hs
+++ b/hspec-src/Flesh/Language/Parser/TestUtil.hs
@@ -28,6 +28,7 @@ import Control.Monad.Identity (Identity, runIdentity)
 import Control.Monad.Reader (ReaderT, runReaderT)
 import Control.Monad.State.Strict (StateT, get, modify', put, runStateT)
 import Control.Monad.Trans.Class (lift)
+import Data.Foldable (for_)
 import Data.Map.Strict (insert, singleton)
 import Data.Text (pack)
 import qualified Flesh.Language.Alias as Alias
@@ -86,6 +87,11 @@ instance MonadInput Overrun where
   pushChars (c:cs) = do
     pushChars cs
     Overrun $ modify' (c :~)
+
+  maybeReparse m = Overrun $ do
+    (maybeChars, result) <- runOverrun m
+    for_ maybeChars $ runOverrun . pushChars
+    return result
 
 type TesterT m = ParserT (RecordT (ReaderT Alias.DefinitionSet m))
 type OverrunTester = TesterT Overrun

--- a/hspec-src/Flesh/Language/Parser/TestUtil.hs
+++ b/hspec-src/Flesh/Language/Parser/TestUtil.hs
@@ -15,6 +15,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -}
 
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE Trustworthy #-}
@@ -83,15 +84,11 @@ instance MonadInput Overrun where
 
   currentPosition = Overrun $ headPosition <$> get
 
-  pushChars [] = return ()
-  pushChars (c:cs) = do
-    pushChars cs
-    Overrun $ modify' (c :~)
-
   maybeReparse m = Overrun $ do
     (maybeChars, result) <- runOverrun m
-    for_ maybeChars $ runOverrun . pushChars
+    for_ maybeChars $ modify' . push
     return result
+      where push newcs oldcs = foldr (:~) oldcs newcs
 
 type TesterT m = ParserT (RecordT (ReaderT Alias.DefinitionSet m))
 type OverrunTester = TesterT Overrun

--- a/src/Flesh/Language/Parser/Alias.hs
+++ b/src/Flesh/Language/Parser/Alias.hs
@@ -149,6 +149,11 @@ instance MonadInput m => MonadInput (AliasT m) where
   peekChar = lift peekChar
   currentPosition = lift currentPosition
   pushChars cs = AliasT $ Nothing <$ pushChars cs
+  maybeReparse = mapAliasT $ maybeReparse . fmap f
+    where f Nothing                         = (Nothing, Nothing)
+          f (Just (_,  (mpcs@(Just _), _))) = (mpcs,    Nothing)
+          f (Just (ma, (Nothing,       a))) = (Nothing, Just (ma', a))
+            where ma' = fmap maybeReparse ma
 
 instance MonadInputRecord m => MonadInputRecord (AliasT m) where
   reverseConsumedChars = lift reverseConsumedChars

--- a/src/Flesh/Language/Parser/Alias.hs
+++ b/src/Flesh/Language/Parser/Alias.hs
@@ -148,7 +148,6 @@ instance MonadInput m => MonadInput (AliasT m) where
     where f (_, a) = (Nothing, a)
   peekChar = lift peekChar
   currentPosition = lift currentPosition
-  pushChars cs = AliasT $ Nothing <$ pushChars cs
   maybeReparse = mapAliasT $ maybeReparse . fmap f
     where f Nothing                         = (Nothing, Nothing)
           f (Just (_,  (mpcs@(Just _), _))) = (mpcs,    Nothing)

--- a/src/Flesh/Language/Parser/Alias.hs
+++ b/src/Flesh/Language/Parser/Alias.hs
@@ -36,10 +36,10 @@ module Flesh.Language.Parser.Alias (
   -- * AliasT
   AliasT(..), mapAliasT, runAliasT, evalAliasT, fromMaybeT,
   -- * Helper functions
-  isAfterBlankEndingSubstitution, substituteAlias, maybeAliasValue) where
+  isAfterBlankEndingSubstitution, maybeAliasValue) where
 
 import Control.Applicative (Alternative, empty, (<|>))
-import Control.Monad (MonadPlus, ap, guard, void)
+import Control.Monad (MonadPlus, ap, guard)
 import Control.Monad.Reader (MonadReader, ReaderT, ask, local, reader)
 import Control.Monad.Trans.Class (MonadTrans, lift)
 import Control.Monad.Trans.Maybe (MaybeT(MaybeT), runMaybeT)
@@ -193,17 +193,6 @@ applicable t (Position (Fragment _ (Alias pos def) _) _)
   | name def == t = False
   | otherwise     = applicable t pos
 applicable _ _ = True
-
--- | Performs alias substitution if the text is an alias defined in the
--- context. The substitution is inserted into the input text by 'pushChars'.
---
--- This function substitutes a single alias only. It does not substitute
--- recursively nor substitute the next token (for an alias value ending with a
--- blank).
-substituteAlias :: (MonadReader DefinitionSet m, MonadInput m)
-                => Position -> Text -> m ()
-substituteAlias pos' t = void $ runMaybeT $
-  maybeAliasValue pos' t >>= pushChars
 
 -- | Returns the alias value if the position and text match an alias in the
 -- current context.

--- a/src/Flesh/Language/Parser/Alias.hs
+++ b/src/Flesh/Language/Parser/Alias.hs
@@ -34,7 +34,7 @@ module Flesh.Language.Parser.Alias (
   -- * Context
   ContextT,
   -- * AliasT
-  AliasT(..), mapAliasT, runAliasT, evalAliasT, fromMaybeT,
+  AliasT, mapAliasT, runAliasT, evalAliasT, fromMaybeT,
   -- * Helper functions
   isAfterBlankEndingSubstitution, maybeAliasValue) where
 

--- a/src/Flesh/Language/Parser/Capture.hs
+++ b/src/Flesh/Language/Parser/Capture.hs
@@ -89,7 +89,6 @@ instance MonadInput m => MonadInput (CaptureT m) where
   lookahead = CaptureT . censor (const []) . lookahead . getCaptureT
   peekChar = lift peekChar
   currentPosition = lift currentPosition
-  pushChars = lift . pushChars
   maybeReparse = CaptureT . pass . fmap f . maybeReparse' . getCaptureT
     where f (Nothing, a) = (a, id)
           f (Just _,  a) = (a, const [])

--- a/src/Flesh/Language/Parser/Capture.hs
+++ b/src/Flesh/Language/Parser/Capture.hs
@@ -34,7 +34,7 @@ module Flesh.Language.Parser.Capture (
 import Control.Applicative (Alternative, empty, many, some, (<|>))
 import Control.Monad (MonadPlus, mplus, mzero)
 import Control.Monad.Trans.Class (MonadTrans, lift)
-import Control.Monad.Writer.Strict (WriterT, censor, runWriterT, tell)
+import Control.Monad.Writer.Strict (WriterT, censor, pass, runWriterT, tell)
 import Flesh.Language.Parser.Error
 import Flesh.Language.Parser.Input
 import Flesh.Source.Position
@@ -90,6 +90,9 @@ instance MonadInput m => MonadInput (CaptureT m) where
   peekChar = lift peekChar
   currentPosition = lift currentPosition
   pushChars = lift . pushChars
+  maybeReparse = CaptureT . pass . fmap f . maybeReparse' . getCaptureT
+    where f (Nothing, a) = (a, id)
+          f (Just _,  a) = (a, const [])
 
 instance MonadInputRecord m => MonadInputRecord (CaptureT m) where
   reverseConsumedChars = lift reverseConsumedChars

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -275,6 +275,7 @@ instance MonadInput m => MonadInput (ParserT m) where
   peekChar = lift peekChar
   currentPosition = lift currentPosition
   pushChars = lift <$> pushChars
+  maybeReparse = mapParserT maybeReparse
 
 instance MonadInputRecord m => MonadInputRecord (ParserT m) where
   reverseConsumedChars = lift reverseConsumedChars

--- a/src/Flesh/Language/Parser/Error.hs
+++ b/src/Flesh/Language/Parser/Error.hs
@@ -274,7 +274,6 @@ instance MonadInput m => MonadInput (ParserT m) where
   lookahead = mapParserT lookahead
   peekChar = lift peekChar
   currentPosition = lift currentPosition
-  pushChars = lift <$> pushChars
   maybeReparse = mapParserT maybeReparse
 
 instance MonadInputRecord m => MonadInputRecord (ParserT m) where

--- a/src/Flesh/Language/Parser/HereDoc.hs
+++ b/src/Flesh/Language/Parser/HereDoc.hs
@@ -161,6 +161,8 @@ instance MonadParser m => MonadInput (AccumT m) where
   peekChar = lift peekChar
   currentPosition = lift currentPosition
   pushChars = lift . pushChars
+  maybeReparse = mapAccumT $ maybeReparse . fmap f
+    where f ((mpcs, a), s) = (mpcs, (a, s))
 
 instance MonadParser m => MonadInputRecord (AccumT m) where
   reverseConsumedChars = lift reverseConsumedChars

--- a/src/Flesh/Language/Parser/HereDoc.hs
+++ b/src/Flesh/Language/Parser/HereDoc.hs
@@ -49,10 +49,10 @@ module Flesh.Language.Parser.HereDoc (
   Filler, popContent,
   -- * HereDocT
   HereDocT(..), runHereDocT, mapHereDocT, hereDocTAccumT, runHereDocTAccumT,
-  fill, setReasonHD, requireHD) where
+  joinHereDocT, fill, setReasonHD, requireHD) where
 
 import Control.Applicative (Alternative, empty, many, some, (<|>))
-import Control.Monad (MonadPlus)
+import Control.Monad (MonadPlus, join)
 import Control.Monad.State.Strict (
   MonadState, State, StateT, evalStateT, get, mapStateT, put, runState, state)
 import Control.Monad.Trans.Class (MonadTrans, lift)
@@ -219,6 +219,9 @@ instance MonadPlus m => Alternative (HereDocT m) where
 
 instance MonadTrans HereDocT where
   lift = HereDocT . lift . fmap return
+
+joinHereDocT :: MonadParser m => m (HereDocT m a) -> HereDocT m a
+joinHereDocT = HereDocT . join . lift . fmap runHereDocT
 
 -- | Fills the accumulated contents into the filler monad, producing the final
 -- parse result.

--- a/src/Flesh/Language/Parser/HereDoc.hs
+++ b/src/Flesh/Language/Parser/HereDoc.hs
@@ -160,7 +160,6 @@ instance MonadParser m => MonadInput (AccumT m) where
   lookahead = mapAccumT lookahead
   peekChar = lift peekChar
   currentPosition = lift currentPosition
-  pushChars = lift . pushChars
   maybeReparse = mapAccumT $ maybeReparse . fmap f
     where f ((mpcs, a), s) = (mpcs, (a, s))
 

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -202,9 +202,9 @@ identifiedToken :: (MonadParser m, MonadReader Alias.DefinitionSet m)
 identifiedToken isReserved' isAliasable isAssignable = do
   iabes <- isAfterBlankEndingSubstitution
   pos <- currentPosition
-  it <- AliasT $ do
+  it <- maybeReparse $ do
     t <- neutralToken
-    getAliasT $ identify isReserved' (isAliasable || iabes) isAssignable pos t
+    identify isReserved' (isAliasable || iabes) isAssignable pos t
   return (pos, it)
 
 aliasableToken :: (MonadParser m, MonadReader Alias.DefinitionSet m)

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -198,7 +198,7 @@ identifiedToken :: (MonadParser m, MonadReader Alias.DefinitionSet m)
                 -- argument is ignored.
                 -> Bool
                 -- ^ Whether the token should be checked for an assignment.
-                -> AliasT m (Positioned IdentifiedToken)
+                -> m (Positioned IdentifiedToken)
 identifiedToken isReserved' isAliasable isAssignable = do
   iabes <- isAfterBlankEndingSubstitution
   pos <- currentPosition
@@ -208,7 +208,7 @@ identifiedToken isReserved' isAliasable isAssignable = do
   return (pos, it)
 
 aliasableToken :: (MonadParser m, MonadReader Alias.DefinitionSet m)
-               => AliasT m Token
+               => m Token
 aliasableToken = do
   t <- identifiedToken (const False) True False
   case snd t of
@@ -371,9 +371,8 @@ braceGroupTail p = do
             literal reservedCloseBrace
 
 -- | Parses an "in" clause of a for loop.
-inClause :: (MonadParser m, MonadReader Alias.DefinitionSet m)
-         => AliasT m [Token]
-inClause = lift (literal reservedIn) *> many aliasableToken
+inClause :: (MonadParser m, MonadReader Alias.DefinitionSet m) => m [Token]
+inClause = literal reservedIn *> many aliasableToken
 
 -- | Parses a 'compoundList' surrounded with the "do" and "done" keywords.
 doGroup :: (MonadParser m, MonadReader Alias.DefinitionSet m)

--- a/src/Flesh/Language/Parser/Syntax.hs
+++ b/src/Flesh/Language/Parser/Syntax.hs
@@ -354,8 +354,7 @@ braceGroupTail :: (MonadParser m, MonadReader Alias.DefinitionSet m)
                => Position -- ^ Position of the open brace.
                -> HereDocT m (Positioned CompoundCommand)
 braceGroupTail p = do
-  body <- setReasonHD (MissingCommandAfter openBraceString) $
-    mapHereDocT evalAliasT compoundList
+  body <- setReasonHD (MissingCommandAfter openBraceString) compoundList
   _ <- closeBrace
   pure (p, Grouping body)
     where openBraceString = unpack reservedOpenBrace

--- a/src/Flesh/Language/Pretty.hs
+++ b/src/Flesh/Language/Pretty.hs
@@ -158,14 +158,14 @@ instance (MonadState InputRecord m, MonadIO m) => MonadInput (CursorT m) where
       [] -> lift (inputCharPosition i)
       ((p, _):_) -> return p
 
-  pushChars cs = CursorT $ do
-    InputPosition {underlyingIndex = i, pushedChars = pcs} <- get
-    put InputPosition {underlyingIndex = i, pushedChars = cs ++ pcs}
-
   maybeReparse (CursorT m) = CursorT $ do
     (mpcs, v) <- m
-    for_ mpcs $ runCursorT . pushChars
+    for_ mpcs push
     return v
+      where push cs = do
+              -- TODO: Use Lens
+              InputPosition {underlyingIndex = i, pushedChars = pcs} <- get
+              put InputPosition {underlyingIndex = i, pushedChars = cs ++ pcs}
 
 readCompleteLine :: IO (Either Failure [AndOrList])
 readCompleteLine = runStandardInputT $ runExceptT $ runCursorT' $

--- a/src/Flesh/Language/Pretty.hs
+++ b/src/Flesh/Language/Pretty.hs
@@ -35,6 +35,7 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Reader (runReaderT)
 import Control.Monad.State.Strict (MonadState, StateT, get, put, runStateT)
 import Control.Monad.Trans.Class (lift)
+import Data.Foldable (for_)
 import Data.Map.Lazy (empty)
 import Flesh.Language.Parser.Char
 import Flesh.Language.Parser.Error
@@ -160,6 +161,11 @@ instance (MonadState InputRecord m, MonadIO m) => MonadInput (CursorT m) where
   pushChars cs = CursorT $ do
     InputPosition {underlyingIndex = i, pushedChars = pcs} <- get
     put InputPosition {underlyingIndex = i, pushedChars = cs ++ pcs}
+
+  maybeReparse (CursorT m) = CursorT $ do
+    (mpcs, v) <- m
+    for_ mpcs $ runCursorT . pushChars
+    return v
 
 readCompleteLine :: IO (Either Failure [AndOrList])
 readCompleteLine = runStandardInputT $ runExceptT $ runCursorT' $


### PR DESCRIPTION
This is rework of #78, implementing part of #77.

- [x] Add a new method to `MonadInput` that supports input text replacement.
- [x] Migrate to the new method, obsoleting `pushChars`.
- [x] Remove `pushChars`.
- [x] Retype parsers that don't have to be `AliasT`.
- [x] Make `getAliasT` private.
- [x] Remove unnecessary alias parser monad use.
